### PR TITLE
add reaction of new emoji to post of emoji-notifier

### DIFF
--- a/emoji-notifier/index.js
+++ b/emoji-notifier/index.js
@@ -10,7 +10,7 @@ module.exports = (clients) => {
 				text: stripIndent`
 					絵文字 \`:${data.name}:\` が追加されました :+1::tada::muscle::raised_hands::innocent:
 				`,
-				username: 'emoji-notifier',
+				username: `emoji-notifier (${data.name})`,
 				// eslint-disable-next-line camelcase
 				icon_emoji: `:${data.name}:`,
 			});

--- a/emoji-notifier/index.js
+++ b/emoji-notifier/index.js
@@ -5,7 +5,7 @@ module.exports = (clients) => {
 
 	rtm.on('emoji_changed', async (data) => {
 		if (data.subtype === 'add') {
-			await slack.chat.postMessage({
+			const message = await slack.chat.postMessage({
 				channel: process.env.CHANNEL_RANDOM,
 				text: stripIndent`
 					絵文字 \`:${data.name}:\` が追加されました :+1::tada::muscle::raised_hands::innocent:
@@ -13,6 +13,11 @@ module.exports = (clients) => {
 				username: 'emoji-notifier',
 				// eslint-disable-next-line camelcase
 				icon_emoji: `:${data.name}:`,
+			});
+			slack.reactions.add({
+				name: data.name,
+				channel: message.channel,
+				timestamp: message.ts,
 			});
 		}
 

--- a/emoji-notifier/index.test.js
+++ b/emoji-notifier/index.test.js
@@ -14,7 +14,8 @@ beforeEach(() => {
 it('responds to emoji addition', () => new Promise((resolve) => {
 	slack.on('chat.postMessage', ({channel, text, username, icon_emoji: icon}) => {
 		expect(channel).toBe(slack.fakeChannel);
-		expect(username).toBe('emoji-notifier');
+		expect(username).toContain('emoji-notifier');
+		expect(username).toContain('hoge');
 		expect(text).toContain(':hoge:');
 		expect(text).toContain('追加');
 		expect(icon).toBe(':hoge:');

--- a/emoji-notifier/index.test.js
+++ b/emoji-notifier/index.test.js
@@ -21,6 +21,12 @@ it('responds to emoji addition', () => new Promise((resolve) => {
 		resolve();
 	});
 
+	slack.on('reactions.add', ({name, channel}) => {
+		expect(name).toBe(':hoge:');
+		expect(channel).toBe(slack.fakeChannel);
+		resolve();
+	});
+
 	slack.rtmClient.emit('emoji_changed', {
 		subtype: 'add',
 		name: 'hoge',

--- a/emoji-notifier/index.test.js
+++ b/emoji-notifier/index.test.js
@@ -11,28 +11,33 @@ beforeEach(() => {
 	emojiNotifier(slack);
 });
 
-it('responds to emoji addition', () => new Promise((resolve) => {
-	slack.on('chat.postMessage', ({channel, text, username, icon_emoji: icon}) => {
-		expect(channel).toBe(slack.fakeChannel);
-		expect(username).toContain('emoji-notifier');
-		expect(username).toContain('hoge');
-		expect(text).toContain(':hoge:');
-		expect(text).toContain('追加');
-		expect(icon).toBe(':hoge:');
-		resolve();
-	});
-
-	slack.on('reactions.add', ({name, channel}) => {
-		expect(name).toBe(':hoge:');
-		expect(channel).toBe(slack.fakeChannel);
-		resolve();
-	});
-
+it('responds to emoji addition', () => {
+	const promise = Promise.all([
+		new Promise((resolve) => {
+			slack.on('chat.postMessage', ({channel, text, username, icon_emoji: icon}) => {
+				expect(channel).toBe(slack.fakeChannel);
+				expect(username).toContain('emoji-notifier');
+				expect(username).toContain('hoge');
+				expect(text).toContain(':hoge:');
+				expect(text).toContain('追加');
+				expect(icon).toBe(':hoge:');
+				resolve();
+			});
+		}),
+		new Promise((resolve) => {
+			slack.on('reactions.add', ({name}) => {
+				expect(name).toBe('hoge');
+				resolve();
+			});
+		}),
+	]);
 	slack.rtmClient.emit('emoji_changed', {
 		subtype: 'add',
 		name: 'hoge',
 	});
-}));
+
+	return promise;
+});
 
 it('responds to emoji removal', () => new Promise((resolve) => {
 	slack.on('chat.postMessage', ({channel, text, username, icon_emoji: icon}) => {


### PR DESCRIPTION
emoji-notifierが「絵文字`:fuga:`が追加されました」って言うついでにそのメッセージに:fuga:でリアクションします。

現状では`icon_emoji`に:fuga:が登録されていて，そこから絵文字を見ることができますが，絵文字が一気に登録されると前のメッセージと統合されて絵文字を見ることができません（スレッドから見れないこともないですが）。あと部員がよく絵文字追加のメッセージに:fuga:でリアクションしてるのでそれが押しやすくなると思います。