### PR TITLE
fix test of emoji-notifier

### DIFF
--- a/emoji-notifier/index.test.js
+++ b/emoji-notifier/index.test.js
@@ -7,7 +7,7 @@ let slack = null;
 
 beforeEach(() => {
 	slack = new Slack();
-	process.env.CHANNEL_RANDOM = slack.fakeChannel;
+	process.env.CHANNEL_SANDBOX = slack.fakeChannel;
 	emojiNotifier(slack);
 });
 


### PR DESCRIPTION
#52 でemoji-notifierのチャンネルをsandboxに変更したことでテストが落ちていたので直しました。