### PR TITLE
lyrics: Make result from uta-net random

### DIFF
--- a/__mocks__/tinyreq.js
+++ b/__mocks__/tinyreq.js
@@ -1,0 +1,15 @@
+/* eslint-env node, jest */
+
+const {PassThrough} = require('stream');
+
+const tinyreq = (...args) => (
+	tinyreq.impl(...args)
+);
+
+tinyreq.impl = jest.fn(() => {
+	return Promise.resolve(tinyreq.response);
+});
+
+tinyreq.response = '';
+
+module.exports = tinyreq;


### PR DESCRIPTION
同じ検索クエリを投げると毎回同じ答えが帰ってくるのが微妙なため。

* axios => JSDOM を廃止し全部scrape-itに
  * itunesが残ってるので全部ではなかった。まあ
* 歌詞の昇順に200件取得して、その中からランダムに選択するよう修正