### PR TITLE
クロスワードの盤面を毎回新規で投稿しない

### DIFF
--- a/wordhero/crossword.ts
+++ b/wordhero/crossword.ts
@@ -150,19 +150,16 @@ export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
 					}))],
 				});
 			} else {
-				const cloudinaryDataPromise = (async () => {
-					await slack.reactions.add({
-						name: '+1',
-						channel: message.channel,
-						timestamp: message.ts,
-					});
+				slack.reactions.add({
+					name: '+1',
+					channel: message.channel,
+					timestamp: message.ts,
+				});
 
-					const cloudinaryData: any = await uploadImage(state.board.map((letter, index) => (letter === null ? null : {
-						color: newIndices.has(index) ? 'red' : 'black',
-						letter,
-					})), state.crossword.index);
-					return cloudinaryData;
-				})();
+				const cloudinaryDataPromise = uploadImage(state.board.map((letter, index) => (letter === null ? null : {
+					color: newIndices.has(index) ? 'red' : 'black',
+					letter,
+				})), state.crossword.index);
 
 				await updatesQueue.add(async () => {
 					const cloudinaryData = await cloudinaryDataPromise;

--- a/wordhero/crossword.ts
+++ b/wordhero/crossword.ts
@@ -157,16 +157,15 @@ export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
 					color: newIndices.has(index) ? 'red' : 'black',
 					letter,
 				})), state.crossword.index);
+				const seconds = boardConfigs[state.crossword.index].length * 10;
 
-				await slack.chat.postMessage({
+				await slack.chat.update({
 					channel: process.env.CHANNEL_SANDBOX,
 					text: stripIndent`
-						わいわい！
+						楽しいクロスワードパズルを始めるよ～
+						マスに入ると思う単語を${seconds}秒以内に *スレッドで* 返信してね!
 					`,
-					username: 'crossword',
-					icon_emoji: ':capital_abcd:',
-					thread_ts: state.thread,
-					reply_broadcast: true,
+					ts: state.thread,
 					attachments: [{
 						title: 'Cross Word',
 						image_url: cloudinaryData.secure_url,


### PR DESCRIPTION
クロスワードがけっこう縦幅を取るので、「わいわい！」を毎回新規で投稿しているのを、最初の「始めるよ〜」の投稿を更新していくスタイルに変更します

最後の「残念、クリアならず」か「クリア！」は新規の投稿のままにしてあります