### PR TITLE
cfb: access only once

### DIFF
--- a/context-free/index.ts
+++ b/context-free/index.ts
@@ -1,7 +1,6 @@
 import scrapeIt from 'scrape-it';
 import {RTMClient, WebClient} from '@slack/client';
 import {last} from 'lodash';
-import axios from 'axios';
 
 const normalizeMeaning = (input: string) => {
   let meaning = input;
@@ -35,31 +34,8 @@ const normalizeMeaning = (input: string) => {
   return meaning.trim();
 };
 
-const randomWord = async (): Promise<string> => {
-  const response = await axios.get('https://www.weblio.jp/WeblioRandomSelectServlet', {
-    maxRedirects: 0,
-    validateStatus: null,
-  });
-  const url = response.headers.location;
-  const word = decodeURIComponent(last(url.split('/')));
-  return word;
-};
-
-const getMeaning = async (word: string): Promise<string> => {
-  interface wordData {
-    description: string;
-  }
-  const response = await scrapeIt<wordData>(
-    `https://www.weblio.jp/content/${encodeURIComponent(word)}`,
-    {
-      description: {
-        selector: 'meta[name=description]',
-        attr: 'content',
-      }
-    }
-  );
-  
-  const match = response.data.description.match(/^.+?(とは\?(?<reference>.+?)。|の意味は)(?<meaning>.+)$/);
+const extractMeaning = (description: string): string => {
+  const match = description.match(/^.+?(とは\?(?<reference>.+?)。|の意味は)(?<meaning>.+)$/);
   if (match === null) {
     return 'わからん';
   }
@@ -68,6 +44,32 @@ const getMeaning = async (word: string): Promise<string> => {
     return `${reference}。${normalizeMeaning(meaning)}。`;
   }
   return `${normalizeMeaning(meaning)}。`;
+};
+
+interface Word {
+  word: string;
+  description: string;
+}
+
+const randomWord = async (): Promise<Word> => {
+  const response = await scrapeIt<Word>(
+    'https://www.weblio.jp/WeblioRandomSelectServlet',
+    {
+      word: {
+        selector: 'h2.midashigo',
+        attr: 'title',
+      },
+      description: {
+        selector: 'meta[name=description]',
+        attr: 'content',
+      },
+    }
+  );
+  const description = extractMeaning(response.data.description);
+  return {
+    word: response.data.word,
+    description,
+  };
 };
 
 const randomInterval = () =>
@@ -80,7 +82,7 @@ interface SlackInterface {
 
 export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
   const postWord = async () => {
-    const word = await randomWord();
+    const {word, description} = await randomWord();
     await slack.chat.postMessage({
       channel: process.env.CHANNEL_SANDBOX,
       icon_emoji: ':context:',
@@ -88,12 +90,11 @@ export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
       text: word,
     });
     await new Promise((resolve) => setTimeout(resolve, 10 * 1000));
-    const meaning = await getMeaning(word);
     await slack.chat.postMessage({
       channel: process.env.CHANNEL_SANDBOX,
       icon_emoji: ':man_dancing_2:',
       username: '通りすがりに context free bot の解説をしてくれるおじさん',
-      text: `${word}: ${meaning}`,
+      text: `${word}: ${description}`,
     });
   };
   const repeatPost = () => {

--- a/context-free/index.ts
+++ b/context-free/index.ts
@@ -4,6 +4,7 @@ import {last} from 'lodash';
 
 const normalizeMeaning = (input: string) => {
   let meaning = input;
+  meaning = meaning.replace(/&nbsp;/g, ' ');
   meaning = meaning.replace(/\s*\[.+?\]\s*/g, '');
   meaning = meaning.replace(/（/g, '(');
   meaning = meaning.replace(/）/g, ')');


### PR DESCRIPTION
URIからデコードするのだとスペースが+になるのと、そもそも同じページに2回アクセスするのが無駄な気がしたので
ついでに`&nbsp;`をスペースに
あえて2回やる実装だったならその旨コメントが欲しいです