### PR TITLE
SlackInterfaceを共通化

### DIFF
--- a/achievements/index_production.ts
+++ b/achievements/index_production.ts
@@ -1,6 +1,8 @@
 import qs from 'querystring';
 // eslint-disable-next-line no-unused-vars
-import {WebClient, RTMClient} from '@slack/client';
+import {WebClient} from '@slack/client';
+// eslint-disable-next-line no-unused-vars
+import type {SlackInterface} from '../lib/slack';
 import axios from 'axios';
 import {stripIndent} from 'common-tags';
 import {countBy, throttle, groupBy, get as getter, chunk} from 'lodash';
@@ -9,12 +11,6 @@ import moment from 'moment';
 import db from '../lib/firestore';
 import {Deferred} from '../lib/utils';
 import achievements, {Difficulty} from './achievements';
-
-interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-	messageClient: any,
-}
 
 type users = {
 	chats?: number,

--- a/atcoder/index.ts
+++ b/atcoder/index.ts
@@ -13,9 +13,10 @@ import scrapeIt from 'scrape-it';
 import {increment, unlock} from '../achievements/index.js';
 // @ts-ignore
 import logger from '../lib/logger.js';
+import type {SlackInterface} from '../lib/slack';
 import {getMemberIcon, getMemberName} from '../lib/slackUtils';
 // eslint-disable-next-line no-unused-vars
-import {Results, SlackInterface, Standings} from './types';
+import {Results, Standings} from './types';
 
 const getRatingColor = (rating: number | null) => {
 	// gray

--- a/atcoder/types.d.ts
+++ b/atcoder/types.d.ts
@@ -1,10 +1,3 @@
-import {WebClient, RTMClient} from '@slack/client';
-
-export interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-}
-
 export interface Standings {
 	Fixed: boolean,
 	AdditionalColumns: null,

--- a/better-custom-response/index.ts
+++ b/better-custom-response/index.ts
@@ -1,11 +1,7 @@
 import customResponses from './custom-responses';
 import {sample, shuffle} from 'lodash';
-import {WebClient, RTMClient, MessageAttachment} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 
-interface SlackInterface {
-    rtmClient: RTMClient,
-    webClient: WebClient,
-}
 
 const response = async (text:string) => {
     for (const resp of customResponses.filter((response) => !response.reaction)) {

--- a/context-free/index.ts
+++ b/context-free/index.ts
@@ -1,5 +1,5 @@
 import scrapeIt from 'scrape-it';
-import {RTMClient, WebClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 import {last, escapeRegExp} from 'lodash';
 import plugin from 'fastify-plugin';
 import {getMemberName, getMemberIcon} from '../lib/slackUtils'
@@ -100,11 +100,6 @@ const composePost = async (message: string): Promise<string> => {
 
 const randomInterval = () =>
   1000 * 60 * (90 + (Math.random() - 0.5) * 2 * 60);
-
-interface SlackInterface {
-  rtmClient: RTMClient;
-  webClient: WebClient;
-}
 
 export const server = ({rtmClient: rtm, webClient: slack}: SlackInterface) => plugin (async (fastify, opts, next) => {
   const postWord = async () => {

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -2,7 +2,7 @@
 import logger from '../lib/logger.js';
 import {get} from 'lodash';
 import {FastifyInstance} from 'fastify';
-import {WebClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 import {spawn} from 'child_process';
 // @ts-ignore
 import concat from 'concat-stream';
@@ -21,7 +21,7 @@ import Blocker from './block.js';
 const deployBlocker = new Blocker();
 export const blockDeploy = (name: string) => deployBlocker.block(name);
 
-export const server = ({webClient: slack}: {webClient: WebClient}) => async (fastify: FastifyInstance) => {
+export const server = ({webClient: slack}: SlackInterface) => async (fastify: FastifyInstance) => {
 	let triggered = false;
 
 	const postMessage = (text: string) => (

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -1,4 +1,4 @@
-import {RTMClient, WebClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 // @ts-ignore
 import logger from '../lib/logger.js';
 import loadFont from '../lib/loadFont';
@@ -472,10 +472,6 @@ const runTransformation = async (message: string): Promise<Emoji | EmodiError> =
 // }}}
 
 // user interaction {{{
-interface SlackInterface {
-  rtmClient: RTMClient;
-  webClient: WebClient;
-}
 
 export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
   const {team}: any = await slack.team.info();

--- a/emoxpand/index.ts
+++ b/emoxpand/index.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 // @ts-ignore
 import logger from '../lib/logger.js';
-import {RTMClient, WebClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 import * as _ from 'lodash';
 import plugin from 'fastify-plugin';
 import {getMemberName, getMemberIcon} from '../lib/slackUtils'
@@ -171,11 +171,6 @@ const expandEmoji = (text: string): string =>
   }).join('\n');
 
 //}}}
-
-interface SlackInterface {
-  rtmClient: RTMClient;
-  webClient: WebClient;
-}
 
 export const server = ({rtmClient: rtm, webClient: slack}: SlackInterface) => plugin(async (fastify, opts, next) => {
   const postMessage = (text: string): void => {

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -5,6 +5,11 @@ import sql from 'sql-template-strings';
 import sqlite from 'sqlite';
 import path from 'path';
 
+export interface SlackInterface {
+	rtmClient: RTMClient,
+	webClient: WebClient,
+}
+
 export const rtmClient = new RTMClient(process.env.SLACK_TOKEN);
 export const webClient = new WebClient(process.env.SLACK_TOKEN);
 

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -1,4 +1,6 @@
 import {RTMClient, WebClient} from '@slack/client';
+import {createEventAdapter} from '@slack/events-api';
+import {createMessageAdapter} from '@slack/interactive-messages';
 import {Deferred} from './utils';
 import {Token} from '../oauth/tokens';
 import sql from 'sql-template-strings';
@@ -6,9 +8,11 @@ import sqlite from 'sqlite';
 import path from 'path';
 
 export interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-}
+	rtmClient: RTMClient;
+	webClient: WebClient;
+	eventClient: ReturnType<typeof createEventAdapter>;
+	messageClient: ReturnType<typeof createMessageAdapter>;
+};
 
 export const rtmClient = new RTMClient(process.env.SLACK_TOKEN);
 export const webClient = new WebClient(process.env.SLACK_TOKEN);

--- a/lyrics/index.ts
+++ b/lyrics/index.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import scrapeIt from 'scrape-it';
 import { AllHtmlEntities } from 'html-entities';
-import { RTMClient, WebClient } from '@slack/client';
+import type { SlackInterface } from '../lib/slack';
 import { escapeRegExp, sample } from 'lodash';
 import qs from 'querystring';
 
@@ -27,11 +27,6 @@ interface MovieInfo {
 interface iTuensInfo {
     audioUrl: string | null;
     artworkUrl: string | null;
-}
-
-interface SlackInterface {
-    rtmClient: RTMClient;
-    webClient: WebClient;
 }
 
 const getiTunesInfo = async (title: string, artist: string): Promise<iTuensInfo> => {

--- a/oauth/index.ts
+++ b/oauth/index.ts
@@ -1,5 +1,5 @@
 import {FastifyInstance} from 'fastify';
-import {WebClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 // @ts-ignore
 import logger from '../lib/logger.js';
 import sqlite from 'sqlite';
@@ -7,7 +7,7 @@ import path from 'path';
 import sql from 'sql-template-strings';
 import {get} from 'lodash';
 
-export const server = ({webClient: slack}: {webClient: WebClient}) => async (fastify: FastifyInstance) => {
+export const server = ({webClient: slack}: SlackInterface) => async (fastify: FastifyInstance) => {
 	const db = await sqlite.open(path.join(__dirname, '..', 'tokens.sqlite3'));
 	await db.run(`
 		CREATE TABLE IF NOT EXISTS tokens (

--- a/oogiri/index.ts
+++ b/oogiri/index.ts
@@ -3,6 +3,7 @@
 /* eslint-disable react/no-access-state-in-setstate */
 // eslint-disable-next-line no-unused-vars
 import {KnownBlock, RTMClient, WebClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 import {constants, promises as fs} from 'fs';
 import {flatten, isEmpty, range, shuffle, times, uniq} from 'lodash';
 import {Deferred} from '../lib/utils';
@@ -12,12 +13,6 @@ import path from 'path';
 import plugin from 'fastify-plugin';
 // @ts-ignore
 import {stripIndent} from 'common-tags';
-
-interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-	messageClient: any,
-}
 
 interface Meaning {
 	user: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1407,23 +1407,65 @@
       }
     },
     "@jest/types": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
+      "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^13.0.0"
+        "@types/yargs": "^15.0.0",
+        "chalk": "^3.0.0"
       },
       "dependencies": {
-        "@types/yargs": {
-          "version": "13.0.8",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
-          "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "@types/yargs-parser": "*"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -1900,12 +1942,13 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.24.tgz",
-      "integrity": "sha512-vgaG968EDPSJPMunEDdZvZgvxYSmeH8wKqBlHSkBt1pV2XlLEVDzsj1ZhLuI4iG4Pv841tES61txSBF0obh4CQ==",
+      "version": "25.1.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.1.3.tgz",
+      "integrity": "sha512-jqargqzyJWgWAJCXX96LBGR/Ei7wQcZBvRv0PLEu9ZByMfcs23keUJrKv9FMR6YZf9YCbfqDqgmY+JUBsnqhrg==",
       "dev": true,
       "requires": {
-        "jest-diff": "^24.3.0"
+        "jest-diff": "^25.1.0",
+        "pretty-format": "^25.1.0"
       }
     },
     "@types/jsdom": {
@@ -2361,7 +2404,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-find-index": {
@@ -3308,7 +3351,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -4573,12 +4616,12 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "requires": {
             "object-assign": "^4.0.1",
@@ -4755,9 +4798,9 @@
       "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
     },
     "diff-sequences": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.1.0.tgz",
+      "integrity": "sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==",
       "dev": true
     },
     "director": {
@@ -5214,7 +5257,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -6477,7 +6520,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figures": {
@@ -7411,7 +7454,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -7634,7 +7677,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
         },
         "pify": {
@@ -8161,7 +8204,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "requires": {
         "from2": "^2.1.1",
@@ -9145,15 +9188,67 @@
       }
     },
     "jest-diff": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
-      "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.1.0.tgz",
+      "integrity": "sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "diff-sequences": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "pretty-format": "^24.9.0"
+        "chalk": "^3.0.0",
+        "diff-sequences": "^25.1.0",
+        "jest-get-type": "^25.1.0",
+        "pretty-format": "^25.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-docblock": {
@@ -9428,9 +9523,9 @@
       }
     },
     "jest-get-type": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
+      "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
       "dev": true
     },
     "jest-haste-map": {
@@ -11344,7 +11439,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -11566,7 +11661,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11680,7 +11775,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true,
           "optional": true
@@ -11727,7 +11822,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
         "camelcase-keys": "^2.0.0",
@@ -11744,7 +11839,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -11881,7 +11976,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -11922,7 +12017,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -12946,7 +13041,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -12959,7 +13054,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -12997,7 +13092,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
@@ -13077,7 +13172,7 @@
       "dependencies": {
         "got": {
           "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
@@ -13195,7 +13290,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -13363,7 +13458,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -14034,21 +14129,52 @@
       }
     },
     "pretty-format": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.1.0.tgz",
+      "integrity": "sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.9.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
+        "@jest/types": "^25.1.0",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^16.12.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "react-is": {
+          "version": "16.12.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
           "dev": true
         }
       }
@@ -14282,7 +14408,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -14380,7 +14506,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -15433,7 +15559,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -16359,7 +16485,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -16716,7 +16842,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -16904,9 +17030,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-jest": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.2.0.tgz",
-      "integrity": "sha512-Yc+HLyldlIC9iIK8xEN7tV960Or56N49MDP7hubCZUeI7EbIOTsas6rXCMB4kQjLACJ7eDOF4xWEO5qumpKsag==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.2.1.tgz",
+      "integrity": "sha512-TnntkEEjuXq/Gxpw7xToarmHbAafgCaAzOpnajnFC6jI7oo1trMzAHA04eWpc3MhV6+yvhE8uUBAmN+teRJh0A==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -16918,24 +17044,7 @@
         "mkdirp": "0.x",
         "resolve": "1.x",
         "semver": "^5.5",
-        "yargs-parser": "10.x"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
+        "yargs-parser": "^16.1.0"
       }
     },
     "ts-node": {
@@ -17060,9 +17169,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw=="
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ=="
     },
     "typpy": {
       "version": "2.3.11",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "suncalc": "^1.8.0",
     "trie-prefix-tree": "^1.5.1",
     "ts-node": "^8.5.4",
-    "typescript": "^3.7.3",
+    "typescript": "^3.8.2",
     "utf-8-validate": "^5.0.2",
     "winston": "^3.2.1",
     "word2vec": "github:pizzacat83/node-word2vec",
@@ -97,7 +97,7 @@
   },
   "devDependencies": {
     "@hakatashi/eslint-config": "^1.12.0",
-    "@types/jest": "^24.0.23",
+    "@types/jest": "^25.1.3",
     "@types/lodash": "^4.14.149",
     "@typescript-eslint/parser": "^2.11.0",
     "byline": "^5.0.0",
@@ -109,7 +109,7 @@
     "mock-cloud-firestore": "^0.11.0",
     "nodemon": "^2.0.2",
     "prettier-eslint-cli": "^5.0.0",
-    "ts-jest": "^24.2.0"
+    "ts-jest": "^25.2.1"
   },
   "optionalDependencies": {}
 }

--- a/ponpe/index.ts
+++ b/ponpe/index.ts
@@ -1,4 +1,4 @@
-import {WebClient, RTMClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 import moment from 'moment';
 import axios from 'axios';
 // @ts-ignore
@@ -8,11 +8,6 @@ import fs from 'fs';
 import {getMemberName, getEmoji} from '../lib/slackUtils';
 import path from 'path';
 import {download} from '../lib/download';
-
-interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-}
 
 function getTimeLink(time:number){
 	return moment(time).utcOffset('+0900').format('HH:mm:ss');

--- a/scrapbox/index.ts
+++ b/scrapbox/index.ts
@@ -2,17 +2,11 @@ import axios from 'axios';
 // @ts-ignore
 import logger from '../lib/logger.js';
 import {LinkUnfurls} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 import qs from 'querystring';
 
 const getScrapboxUrl = (pageName: string) => `https://scrapbox.io/api/pages/tsg/${pageName}`;
 
-import {WebClient, RTMClient} from '@slack/client';
-
-interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-	eventClient: any,
-}
 
 export default async ({rtmClient: rtm, webClient: slack, eventClient: event}: SlackInterface) => {
 	event.on('link_shared', async (e: any) => {

--- a/slack-log/index.ts
+++ b/slack-log/index.ts
@@ -8,13 +8,7 @@ const slacklogAPIDomain = 'localhost:9292';
 const slacklogURLRegexp = new RegExp('^https?://slack-log.tsg.ne.jp/([A-Z0-9]+)/([0-9]+\.[0-9]+)');
 const getAroundMessagesUrl = (channel: string) => `http://${slacklogAPIDomain}/around_messages/${channel}.json`;
 
-import {WebClient, RTMClient} from '@slack/client';
-
-interface SlackInterface {
-    rtmClient: RTMClient,
-    webClient: WebClient,
-    eventClient: any,
-}
+import type {SlackInterface} from '../lib/slack';
 
 export default async ({rtmClient: rtm, webClient: slack, eventClient: event}: SlackInterface) => {
     const users = await axios.get(`http://${slacklogAPIDomain}/users.json`).then(({data}) => data);

--- a/tiobot/index.ts
+++ b/tiobot/index.ts
@@ -1,12 +1,7 @@
 // @ts-ignore
 import {stripIndent} from 'common-tags';
 import * as zlib from 'zlib';
-import {WebClient, RTMClient} from '@slack/client';
-
-interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-}
+import type {SlackInterface} from '../lib/slack';
 
 export default ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
 	rtm.on('message', async (message) => {

--- a/tsglive/index.ts
+++ b/tsglive/index.ts
@@ -1,12 +1,7 @@
-import {RTMClient, WebClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 import db from '../lib/firestore';
 import {getMemberName} from '../lib/slackUtils';
 import plugin from 'fastify-plugin';
-
-interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-}
 
 export const server = ({webClient: slack}: SlackInterface) => plugin(async (fastify, opts, next) => {
 	const {team}: any = await slack.team.info();

--- a/tunnel/index.ts
+++ b/tunnel/index.ts
@@ -1,4 +1,5 @@
-import {RTMClient, WebClient} from '@slack/client';
+import {WebClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 import {flatten, uniq} from 'lodash';
 import {getEmoji, getMemberIcon, getMemberName} from '../lib/slackUtils';
 import {EmojiData} from 'emoji-data-ts';
@@ -7,11 +8,6 @@ import path from 'path';
 import plugin from 'fastify-plugin';
 import sql from 'sql-template-strings';
 import sqlite from 'sqlite';
-
-interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-}
 
 const messages = new Map();
 

--- a/voiperrobot/index.ts
+++ b/voiperrobot/index.ts
@@ -4,7 +4,7 @@ import tts from 'google-tts-api';
 import moment from 'moment';
 import { stringify } from 'querystring';
 import assert from 'assert';
-import {RTMClient, WebClient} from '@slack/client';
+import type { SlackInterface } from '../lib/slack';
 
 import {unlock} from '../achievements';
 import Mutex from './mutex';
@@ -100,11 +100,6 @@ const hitblow = (seq1: string[], seq2: string[]) => {
 		blow,
 	};
 };
-
-interface SlackInterface {
-	rtmClient: RTMClient;
-	webClient: WebClient;
-}
 
 export default ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
 	rtm.on('message', async (message: any) => {

--- a/welcome/index.ts
+++ b/welcome/index.ts
@@ -4,12 +4,8 @@ import logger from '../lib/logger.js';
 
 const welcomeScrapboxUrl = `https://scrapbox.io/api/pages/tsg/welcome`;
 
-import {WebClient, RTMClient} from '@slack/client';
-
-interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-}
+import {WebClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 
 async function postWelcomeMessage(slack: WebClient, channel: string) {
 	const {data} = await axios.get(welcomeScrapboxUrl, {headers: {Cookie: `connect.sid=${process.env.SCRAPBOX_SID}`}});

--- a/wordhero/crossword.ts
+++ b/wordhero/crossword.ts
@@ -1,4 +1,4 @@
-import {WebClient, RTMClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 import cloudinary from 'cloudinary';
 // @ts-ignore
 import {stripIndent} from 'common-tags';
@@ -10,10 +10,6 @@ import generateCrossword from './generateCrossword';
 import boardConfigs from './boards.json';
 import {unlock, increment} from '../achievements';
 
-interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-}
 
 interface Description {
 	word: string,

--- a/wordhero/index.ts
+++ b/wordhero/index.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import {promisify} from 'util';
 import path from 'path';
 import assert from 'assert';
-import {WebClient, RTMClient} from '@slack/client';
+import type {SlackInterface} from '../lib/slack';
 import {flatten, sum, sample, random, sortBy, maxBy, sumBy, shuffle} from 'lodash';
 // @ts-ignore
 import trie from './trie';
@@ -16,11 +16,6 @@ import download from 'download';
 import sqlite from 'sqlite';
 import render from './render';
 import {Deferred} from '../lib/utils';
-
-interface SlackInterface {
-	rtmClient: RTMClient,
-	webClient: WebClient,
-}
 
 const hiraganaLetters = 'ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろわをんー'.split('');
 


### PR DESCRIPTION
各所で定義されている `SlackInterface` を `lib/slack.ts` に一本化します。
#253 が完成する前でも他のPRを手掛けてる人がこのブランチをMergeできるので， #253 における `@slack/client` 周りの修正が多少減ることを期待しています。

## 変更
- `typescript` をアップデート
  + type-only import のため
- `ts-jest` をアップデート
  + `jest@25.1` に対応しているバージョンに
- 各ファイルの `SlackInterface` の定義を削除し，代わりに `../lib/slack` からimport

### その他の `import '@slack/client'` について
例えばtunnelなどは `SlackInterface` とは別に `WebClient` を使っていて，このような場合はimportはそのままにしています。 わざわざ `WebClient` を `lib/slack` でimportしてexportするのは微妙だと思ったので。これらは #253 で適切なimportに書き換えます。 `import '@slack/client'` が残っているファイルのリストは[コメント](#issuecomment-590730518)にあります。
