### PR TITLE
Fix: fixed #293

### DIFF
--- a/oogiri/index.ts
+++ b/oogiri/index.ts
@@ -306,7 +306,7 @@ class Oogiri {
 					},
 					{
 						type: 'mrkdwn',
-						text: `＊BET可能枚数＊ ${game.maxMeanings}枚`,
+						text: `＊BET可能枚数＊ ${game.maxCoins}枚`,
 					},
 				],
 				accessory: {


### PR DESCRIPTION
#293 oogiriの大喜利開始メッセージでBET可能枚数のところに最大意味登録可能数が表示されていたのを修正