### PR TITLE
「本日の一句」の出典を変更

### DIFF
--- a/sunrise/fetch.js
+++ b/sunrise/fetch.js
@@ -96,14 +96,16 @@ const getEntries = () => (
 );
 
 const getHaiku = async () => {
-	const {data} = await axios.get('http://sendan.kaisya.co.jp/index3.html', {
-		responseType: 'arraybuffer',
+	const {data} = await axios.get('https://www.haijinkyokai.jp/');
+	const $ = cheerio.load(data);
+	$('rt').each((i, element) => {
+		$(element).remove(); // Remove ruby
 	});
-	const $ = cheerio.load(iconv.decode(data, 'sjis'));
-	const text = $('td[rowspan=9][width=600] center font').text();
-	const author = $('td[rowspan=9][width=600] center b').text();
+	const text = $('#poem1').text();
+	const author = $('#author').text();
+	const note = $('#notes > p').text();
 
-	return {text, author};
+	return {text, author, note};
 };
 
 const getWeather = async (location) => {

--- a/sunrise/index.js
+++ b/sunrise/index.js
@@ -377,9 +377,9 @@ module.exports = async ({rtmClient: rtm, webClient: slack}) => {
 				}] : []), {
 					color: '#6D4C41',
 					title: '本日の一句',
-					title_link: 'http://sendan.kaisya.co.jp/',
+					title_link: 'https://www.haijinkyokai.jp/',
 					text: haiku.text,
-					footer: haiku.author,
+					footer: haiku.note + '\n' + haiku.author,
 				}],
 			});
 


### PR DESCRIPTION
これまでのソースであった[e船団](http://sendan.kaisya.co.jp/)の「今日の一句」は、2020年6月15日を最後に更新が停止されたため、代わりに[俳人協会](https://www.haijinkyokai.jp/)の「今日の一句」を使用するようにしました。