### PR TITLE
mahjong: ゲーム進行中に更に配牌仕様とした際の:ha:の送信先をスレッド内からスレッド外へ

### DIFF
--- a/mahjong/index.js
+++ b/mahjong/index.js
@@ -174,6 +174,10 @@ module.exports = (clients) => {
 			postMessage(':ha:');
 		};
 
+		const perdon_broadcast = () => {
+			postMessage(':ha:', {mode: 'initial'});
+		};
+
 		const generate王牌 = (裏ドラ表示牌s = []) => {
 			const 嶺上牌s = [
 				...Array((state.mode === '四人' ? 4 : 8) - state.嶺上牌Count).fill('\u2003'),
@@ -231,7 +235,7 @@ module.exports = (clients) => {
 
 		if (text === '配牌') {
 			if (state.phase !== 'waiting') {
-				perdon();
+				perdon_broadcast();
 				return;
 			}
 
@@ -269,7 +273,7 @@ module.exports = (clients) => {
 
 		if (text === 'サンマ') {
 			if (state.phase !== 'waiting') {
-				perdon();
+				perdon_broadcast();
 				return;
 			}
 

--- a/mahjong/index.js
+++ b/mahjong/index.js
@@ -174,8 +174,8 @@ module.exports = (clients) => {
 			postMessage(':ha:');
 		};
 
-		const perdon_broadcast = () => {
-			postMessage(':ha:', {mode: 'initial'});
+		const perdonBroadcast = () => {
+			postMessage(':ha:', {mode: 'broadcast'});
 		};
 
 		const generate王牌 = (裏ドラ表示牌s = []) => {
@@ -235,7 +235,7 @@ module.exports = (clients) => {
 
 		if (text === '配牌') {
 			if (state.phase !== 'waiting') {
-				perdon_broadcast();
+				perdonBroadcast();
 				return;
 			}
 
@@ -273,7 +273,7 @@ module.exports = (clients) => {
 
 		if (text === 'サンマ') {
 			if (state.phase !== 'waiting') {
-				perdon_broadcast();
+				perdonBroadcast();
 				return;
 			}
 


### PR DESCRIPTION
進行中の配牌が忘れ去られ新たに配牌されようとしたときに、今の仕様だと進行中のゲームのスレッド内でbotがキレていました。それだと新たに配牌した人が気づきにくい（単に重いのと区別がつかない）ので、スレッドの外に投稿するようにしました。サンマも同様です。