### PR TITLE
hayaoshi: 早押しクイズhardで答えの切り出し方を修正

### DIFF
--- a/hayaoshi/index.ts
+++ b/hayaoshi/index.ts
@@ -97,7 +97,7 @@ const getHardQuiz = async () => {
 
 	// eslint-disable-next-line prefer-destructuring
 	quiz.question = quiz.question.split('<br>')[0];
-	quiz.answer = quiz.answer.replace(/(?:\(.+\)|（.+）|\[.+\]|【.+】)/g, '').trim();
+	quiz.answer = quiz.answer.replace(/(?:\(.+?\)|（.+?）|\[.+?\]|【.+?】)/g, '').trim();
 
 	return quiz;
 };


### PR DESCRIPTION
quiz.answerをreplaceして答えがおかしくなる場合を修正。

例 http://qss.quiz-island.site/abcgo-info/11300
変換前の答え: `明智光秀(あけち・みつひで)【「惟任光秀(これとう・みつひで)」「明智惟任日向守光秀」も○】`
旧: `明智光秀」「明智惟任日向守光秀」も○】`
新: `明智光秀`