### PR TITLE
thread について各 UI で発行される default URL の slacklog-ize 対応

### DIFF
--- a/slack-log/index.test.ts
+++ b/slack-log/index.test.ts
@@ -31,11 +31,29 @@ describe('slacklog', () => {
 		expect(text).toMatch(slack.fakeChannel);
 	});
 
-	it('respond to slacklog-ize request', async () => {
+	it('respond to canonical slacklog-ize request', async () => {
 		const requestURL: string = '<https://tsg-ut.slack.com/archives/C0123ABCD/p1501234567890123>';
 		const {channel, text}: {channel: string, text: string} = await slack.getResponseTo(`slacklog ${requestURL}`);
 
 		const expectURL: string = '<https://slack-log.tsg.ne.jp/C0123ABCD/1501234567.890123>';
+		expect(channel).toBe(slack.fakeChannel);
+		expect(text).toBe(expectURL);
+	});
+
+	it('respond to slacklog-ize request of practical url from default web UI', async () => {
+		const requestURL: string = '<https://tsg-ut.slack.com/archives/C7AAX50QY/p1603287289337400?thread_ts=1603267719.496100&amp;cid=C7AAX50QY>';
+		const {channel, text}: {channel: string, text: string} = await slack.getResponseTo(`slacklog ${requestURL}`);
+
+		const expectURL: string = '<https://slack-log.tsg.ne.jp/C7AAX50QY/1603287289.337400>';
+		expect(channel).toBe(slack.fakeChannel);
+		expect(text).toBe(expectURL);
+	});
+
+	it('respond to slacklog-ize request of practical url from iOS app', async () => {
+		const requestURL: string = '<https://tsg-ut.slack.com/archives/C7AAX50QY/p1603288141348600?thread_ts=1603287978.345500&channel=C7AAX50QY&message_ts=1603288141.348600>';
+		const {channel, text}: {channel: string, text: string} = await slack.getResponseTo(`slacklog ${requestURL}`);
+
+		const expectURL: string = '<https://slack-log.tsg.ne.jp/C7AAX50QY/1603288141.348600>';
 		expect(channel).toBe(slack.fakeChannel);
 		expect(text).toBe(expectURL);
 	});

--- a/slack-log/index.ts
+++ b/slack-log/index.ts
@@ -24,7 +24,7 @@ export default async ({rtmClient: rtm, webClient: slack, eventClient: event}: Sl
         const [command, ...queries] = trim.split(/\s+/);
         if (command === 'slacklog') {
             const url = queries.join(' ');
-            const slackURLRegexp = new RegExp('^<https?://tsg-ut.slack.com/archives/([A-Z0-9]+)/p([0-9]+)([0-9]{6})(\\?thread_ts=[0-9]+.[0-9]+(&amp;cid=[A-Z0-9]+)?)?>');
+            const slackURLRegexp = new RegExp('^<https?://tsg-ut.slack.com/archives/([A-Z0-9]+)/p([0-9]+)([0-9]{6})\\S*>');
 
             if (slackURLRegexp.test(url)) {
                 const [_, chanid, ts1, ts2] = slackURLRegexp.exec(url);

--- a/slack-log/index.ts
+++ b/slack-log/index.ts
@@ -24,7 +24,7 @@ export default async ({rtmClient: rtm, webClient: slack, eventClient: event}: Sl
         const [command, ...queries] = trim.split(/\s+/);
         if (command === 'slacklog') {
             const url = queries.join(' ');
-            const slackURLRegexp = new RegExp('^<https?://tsg-ut.slack.com/archives/([A-Z0-9]+)/p([0-9]+)([0-9]{6})>');
+            const slackURLRegexp = new RegExp('^<https?://tsg-ut.slack.com/archives/([A-Z0-9]+)/p([0-9]+)([0-9]{6})(\\?thread_ts=[0-9]+.[0-9]+(&amp;cid=[A-Z0-9]+)?)?>');
 
             if (slackURLRegexp.test(url)) {
                 const [_, chanid, ts1, ts2] = slackURLRegexp.exec(url);


### PR DESCRIPTION
Close #328 

これまでの slacklog-ize は `https://tsg-ut.slack.com/archives/C0123ABCD/p1501234567890123` のような canonical URL にのみ対応していましたが、各アプリで thread の message の URL をコピーすると余計なパラメータがついてきて、一発で slacklog-ize することができませんでした。
パラメータを無視することで、対応させました。

また、web と iOS の2つの client のコピー形式をテストに記述し、問題ないことを確認しました。

これでくっきーさんの日記がいっそう捗ります。喜ばしいですね。

感想:
* test が完璧なおかげで、いちいち manual test しなくても jest だけで動作検証できてすげ〜
* 一瞬これまでの正規表現でなんで動かないのかわからなくて、罠だな〜と思った (最後に `>` があるのが盲点ですね)

@cookie-s さん、レビューお願いします。