### PR TITLE
hitandblow: Hit & Blow を実装

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,3 +38,4 @@ room-gacha/** @hideo54
 taiko/** @kurgm
 hayaoshi/** @hakatashi
 twitter-dm-notifier/** @hideo54
+hitandblow/** @settyan117

--- a/achievements/achievements.ts
+++ b/achievements/achievements.ts
@@ -1496,7 +1496,7 @@ const achievements: Achievement[] = [
 		category: 'hitandblow',
 	},
 	{
-		id: 'hitandblow-clear-once-over-2digits',
+		id: 'hitandblow-clear-once-2digits-or-more',
 		difficulty: 'professional',
 		title: 'guess問が得意',
 		condition: 'Hit & Blow を一発クリアする (2桁以上)',

--- a/achievements/achievements.ts
+++ b/achievements/achievements.ts
@@ -1482,7 +1482,7 @@ const achievements: Achievement[] = [
 		category: 'hitandblow',
 	},
 	{
-		id: 'hitandblow-clear-over-6digits',
+		id: 'hitandblow-clear-6digits-or-more',
 		difficulty: 'medium',
 		title: '6 Hit 0 Blow',
 		condition: 'Hit & Blow をクリアする (6桁以上)',

--- a/achievements/achievements.ts
+++ b/achievements/achievements.ts
@@ -1496,10 +1496,10 @@ const achievements: Achievement[] = [
 		category: 'hitandblow',
 	},
 	{
-		id: 'hitandblow-clear-once-2digits-or-more',
+		id: 'hitandblow-clear-once-3digits-or-more',
 		difficulty: 'professional',
 		title: 'guess問が得意',
-		condition: 'Hit & Blow を一発クリアする (2桁以上)',
+		condition: 'Hit & Blow を一回のコールでクリアする (3桁以上)',
 		category: 'hitandblow',
 	},
 

--- a/achievements/achievements.ts
+++ b/achievements/achievements.ts
@@ -1465,6 +1465,44 @@ const achievements: Achievement[] = [
 		category: 'ricochet-robots',
 	},
 
+	// hitandblow
+
+	{
+		id: 'hitandblow-play',
+		difficulty: 'easy',
+		title: '0 Hit 1 Blow',
+		condition: 'Hit & Blow で遊ぶ',
+		category: 'hitandblow',
+	},
+	{
+		id: 'hitandblow-clear',
+		difficulty: 'easy',
+		title: '1 Hit 0 Blow',
+		condition: 'Hit & Blow をクリアする',
+		category: 'hitandblow',
+	},
+	{
+		id: 'hitandblow-clear-over-6digits',
+		difficulty: 'medium',
+		title: '6 Hit 0 Blow',
+		condition: 'Hit & Blow をクリアする (6桁以上)',
+		category: 'hitandblow',
+	},
+	{
+		id: 'hitandblow-clear-10digits',
+		difficulty: 'hard',
+		title: '10 Hit 0 Blow',
+		condition: 'Hit & Blow をクリアする (10桁)',
+		category: 'hitandblow',
+	},
+	{
+		id: 'hitandblow-clear-once-over-2digits',
+		difficulty: 'professional',
+		title: 'guess問が得意',
+		condition: 'Hit & Blow を一発クリアする (2桁以上)',
+		category: 'hitandblow',
+	},
+
 	// ahokusa
 
 	{

--- a/hitandblow/.eslintrc.json
+++ b/hitandblow/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+    "prettier/@typescript-eslint"
+  ],
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "sourceType": "module",
+    "project": "./tsconfig.json"
+  },
+  "rules": {}
+}

--- a/hitandblow/.prettierrc.json
+++ b/hitandblow/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "bracketSpacing": true
+}

--- a/hitandblow/index.test.ts
+++ b/hitandblow/index.test.ts
@@ -1,21 +1,23 @@
+import { stripIndent } from 'common-tags';
+import hitandblow from './';
+
 const Slack = require('../lib/slackMock.js');
-const hitandblow = require('./');
 
 let slack: typeof Slack;
 
 beforeEach(() => {
   slack = new Slack();
   process.env.CHANNEL_SANDBOX = slack.fakeChannel;
-  hitandblow(slack.rtmClient, slack.webClient);
+  hitandblow(slack);
 });
 
-describe('responding /^hitandblow( d+)?$/', () => {
-  it('responds to "hitandblow"', async () => {
+describe('response to /^hitandblow( \\d+)?$/', () => {
+  it('starts game by "hitandblow"', async () => {
     const responce = await slack.getResponseTo('hitandblow');
     expect(responce.username).toBe('Hit & Blow');
     expect(responce.text).toContain('Hit & Blow (4桁) を開始します。');
   });
-  it('responds to "hitandblow 5"', async () => {
+  it('starts game by "hitandblow 5"', async () => {
     const responce = await slack.getResponseTo('hitandblow 5');
     expect(responce.username).toBe('Hit & Blow');
     expect(responce.text).toContain('Hit & Blow (5桁) を開始します。');
@@ -26,5 +28,27 @@ describe('responding /^hitandblow( d+)?$/', () => {
     expect(responce.text).toContain(
       '桁数は1以上10以下で指定してね:thinking_face:'
     );
+  });
+});
+
+describe('response to /^hbdiff \\d+ \\d+$/', () => {
+  it('replys diff to "hbdiff 0169237 9587234"', async () => {
+    const responce = await slack.getResponseTo('hbdiff 0169237 9587234');
+    expect(responce.username).toBe('Hit & Blow');
+    expect(responce.text).toBe(stripIndent`
+    >>>~0~ ~1~ ~6~ _9_ *2* *3* _7_
+    _9_ ~5~ ~8~ _7_ *2* *3* ~4~`);
+  });
+  it('replys error to "hbdiff 0138569237 9501687234"', async () => {
+    const responce = await slack.getResponseTo('hbdiff 0138569237 9501687234');
+    expect(responce.username).toBe('Hit & Blow');
+    expect(responce.text).toBe(
+      'どちらかのコール中に同じ数字が含まれているよ:cry:'
+    );
+  });
+  it('replys error to "hbdiff 012 0123"', async () => {
+    const responce = await slack.getResponseTo('hbdiff 012 0123');
+    expect(responce.username).toBe('Hit & Blow');
+    expect(responce.text).toBe('桁数が違うので比較できないよ:cry:');
   });
 });

--- a/hitandblow/index.test.ts
+++ b/hitandblow/index.test.ts
@@ -13,19 +13,19 @@ beforeEach(() => {
 
 describe('response to /^hitandblow( \\d+)?$/', () => {
   it('starts game by "hitandblow"', async () => {
-    const responce = await slack.getResponseTo('hitandblow');
-    expect(responce.username).toBe('Hit & Blow');
-    expect(responce.text).toContain('Hit & Blow (4桁) を開始します。');
+    const response = await slack.getResponseTo('hitandblow');
+    expect(response.username).toBe('Hit & Blow');
+    expect(response.text).toContain('Hit & Blow (4桁) を開始します。');
   });
   it('starts game by "hitandblow 5"', async () => {
-    const responce = await slack.getResponseTo('hitandblow 5');
-    expect(responce.username).toBe('Hit & Blow');
-    expect(responce.text).toContain('Hit & Blow (5桁) を開始します。');
+    const response = await slack.getResponseTo('hitandblow 5');
+    expect(response.username).toBe('Hit & Blow');
+    expect(response.text).toContain('Hit & Blow (5桁) を開始します。');
   });
   it('does not start game by "hitandblow 100"', async () => {
-    const responce = await slack.getResponseTo('hitandblow 100');
-    expect(responce.username).toBe('Hit & Blow');
-    expect(responce.text).toContain(
+    const response = await slack.getResponseTo('hitandblow 100');
+    expect(response.username).toBe('Hit & Blow');
+    expect(response.text).toContain(
       '桁数は1以上10以下で指定してね:thinking_face:'
     );
   });
@@ -33,22 +33,22 @@ describe('response to /^hitandblow( \\d+)?$/', () => {
 
 describe('response to /^hbdiff \\d+ \\d+$/', () => {
   it('replys diff to "hbdiff 0169237 9587234"', async () => {
-    const responce = await slack.getResponseTo('hbdiff 0169237 9587234');
-    expect(responce.username).toBe('Hit & Blow');
-    expect(responce.text).toBe(stripIndent`
+    const response = await slack.getResponseTo('hbdiff 0169237 9587234');
+    expect(response.username).toBe('Hit & Blow');
+    expect(response.text).toBe(stripIndent`
     >>>~0~ ~1~ ~6~ _9_ *2* *3* _7_
     _9_ ~5~ ~8~ _7_ *2* *3* ~4~`);
   });
   it('replys error to "hbdiff 0138569237 9501687234"', async () => {
-    const responce = await slack.getResponseTo('hbdiff 0138569237 9501687234');
-    expect(responce.username).toBe('Hit & Blow');
-    expect(responce.text).toBe(
+    const response = await slack.getResponseTo('hbdiff 0138569237 9501687234');
+    expect(response.username).toBe('Hit & Blow');
+    expect(response.text).toBe(
       'どちらかのコール中に同じ数字が含まれているよ:cry:'
     );
   });
   it('replys error to "hbdiff 012 0123"', async () => {
-    const responce = await slack.getResponseTo('hbdiff 012 0123');
-    expect(responce.username).toBe('Hit & Blow');
-    expect(responce.text).toBe('桁数が違うので比較できないよ:cry:');
+    const response = await slack.getResponseTo('hbdiff 012 0123');
+    expect(response.username).toBe('Hit & Blow');
+    expect(response.text).toBe('桁数が違うので比較できないよ:cry:');
   });
 });

--- a/hitandblow/index.test.ts
+++ b/hitandblow/index.test.ts
@@ -1,0 +1,30 @@
+const Slack = require('../lib/slackMock.js');
+const hitandblow = require('./');
+
+let slack: typeof Slack;
+
+beforeEach(() => {
+  slack = new Slack();
+  process.env.CHANNEL_SANDBOX = slack.fakeChannel;
+  hitandblow(slack.rtmClient, slack.webClient);
+});
+
+describe('responding /^hitandblow( d+)?$/', () => {
+  it('responds to "hitandblow"', async () => {
+    const responce = await slack.getResponseTo('hitandblow');
+    expect(responce.username).toBe('Hit & Blow');
+    expect(responce.text).toContain('Hit & Blow (4桁) を開始します。');
+  });
+  it('responds to "hitandblow 5"', async () => {
+    const responce = await slack.getResponseTo('hitandblow 5');
+    expect(responce.username).toBe('Hit & Blow');
+    expect(responce.text).toContain('Hit & Blow (5桁) を開始します。');
+  });
+  it('does not start game by "hitandblow 100"', async () => {
+    const responce = await slack.getResponseTo('hitandblow 100');
+    expect(responce.username).toBe('Hit & Blow');
+    expect(responce.text).toContain(
+      '桁数は1以上10以下で指定してね:thinking_face:'
+    );
+  });
+});

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -235,10 +235,10 @@ export default ({
               if (state.answer.length === 10) {
                 await unlock(message.user, 'hitandblow-clear-10digits');
               }
-              if (state.answer.length >= 2 && state.history.length === 1) {
+              if (state.answer.length >= 3 && state.history.length === 1) {
                 await unlock(
                   message.user,
-                  'hitandblow-clear-once-2digits-or-more'
+                  'hitandblow-clear-once-3digits-or-more'
                 );
               }
 

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -10,11 +10,18 @@ interface HitAndBlowHistory {
   blowsCount: number;
 }
 
-interface HitAndBlowState {
+class HitAndBlowState {
   answer: number[];
   history: HitAndBlowHistory[];
   thread?: string;
   inGame: boolean;
+  clear() {
+    this.answer = [];
+    this.history = [];
+    this.thread = undefined;
+    this.inGame = false;
+    return;
+  }
 }
 
 const isValidCall = (call: number[]) => {
@@ -80,12 +87,7 @@ export default ({
   rtmClient: RTMClient;
   webClient: WebClient;
 }) => {
-  const state: HitAndBlowState = {
-    answer: [],
-    history: [],
-    thread: undefined,
-    inGame: false,
-  };
+  const state = new HitAndBlowState();
 
   // call履歴をpostする関数
   const postHistory = async (history: HitAndBlowHistory[]) => {
@@ -246,10 +248,7 @@ export default ({
               }
 
               // 終了処理
-              state.answer = [];
-              state.history = [];
-              state.thread = undefined;
-              state.inGame = false;
+              state.clear();
             }
           }
         }
@@ -270,10 +269,9 @@ export default ({
           reply_broadcast: true,
         });
         postHistory(state.history);
-        state.answer = [];
-        state.history = [];
-        state.thread = undefined;
-        state.inGame = false;
+
+        // 終了処理
+        state.clear();
       }
 
       // history処理

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -97,7 +97,7 @@ module.exports = (rtm: RTMClient, slack: WebClient) => {
       });
     }
   };
-  rtm.on('message', async (message) => {
+  rtm.on('message', async message => {
     if (message.channel !== process.env.CHANNEL_SANDBOX) {
       return;
     }
@@ -145,7 +145,6 @@ module.exports = (rtm: RTMClient, slack: WebClient) => {
             icon_emoji: '1234',
           });
           state.thread = ts as string;
-          console.log(state.answer);
         }
       }
     }

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -3,6 +3,7 @@ import { WebClient } from '@slack/web-api';
 import { range, shuffle } from 'lodash';
 import { stripIndent } from 'common-tags';
 import { unlock } from '../achievements';
+import assert from 'assert';
 
 interface HitAndBlowHistory {
   call: number[];
@@ -11,10 +12,10 @@ interface HitAndBlowHistory {
 }
 
 class HitAndBlowState {
-  answer: number[];
-  history: HitAndBlowHistory[];
-  thread?: string;
-  inGame: boolean;
+  answer: number[] = [];
+  history: HitAndBlowHistory[] = [];
+  thread?: string = undefined;
+  inGame: boolean = false;
   clear() {
     this.answer = [];
     this.history = [];
@@ -36,38 +37,32 @@ const isValidCall = (call: number[]) => {
 };
 
 const countHit = (call: number[], answer: number[]) => {
-  if (call.length !== answer.length) {
-    throw new Error('Length of the call does not match the answer.');
-  } else {
-    const hits = new Set<number>();
-    for (let i = 0; i < call.length; i++) {
-      if (call[i] === answer[i]) {
-        hits.add(call[i]);
-      }
+  assert(call.length === answer.length);
+  const hits = new Set<number>();
+  for (let i = 0; i < call.length; i++) {
+    if (call[i] === answer[i]) {
+      hits.add(call[i]);
     }
-    return hits;
   }
+  return hits;
 };
 
 // Hitも合わせて数える
 const countBlow = (call: number[], answer: number[]) => {
-  if (call.length !== answer.length) {
-    throw new Error('Length of the call does not match the answer.');
-  } else {
-    const blows = new Set<number>();
-    const callArray = Array<number>(10).fill(0);
-    const ansArray = Array<number>(10).fill(0);
-    for (let i = 0; i < call.length; i++) {
-      callArray[call[i]]++;
-      ansArray[answer[i]]++;
-    }
-    for (let i = 0; i < 10; i++) {
-      if (Math.min(callArray[i], ansArray[i]) >= 1) {
-        blows.add(i);
-      }
-    }
-    return blows;
+  assert(call.length === answer.length);
+  const blows = new Set<number>();
+  const callArray = Array<number>(10).fill(0);
+  const ansArray = Array<number>(10).fill(0);
+  for (let i = 0; i < call.length; i++) {
+    callArray[call[i]]++;
+    ansArray[answer[i]]++;
   }
+  for (let i = 0; i < 10; i++) {
+    if (Math.min(callArray[i], ansArray[i]) >= 1) {
+      blows.add(i);
+    }
+  }
+  return blows;
 };
 
 const generateHistoryString = ({

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -1,0 +1,229 @@
+import { RTMClient } from '@slack/rtm-api';
+import { WebClient } from '@slack/web-api';
+import { range, shuffle } from 'lodash';
+import { stripIndent } from 'common-tags';
+
+interface HitAndBlowState {
+  answer: number[];
+  history: { call: number[]; hits: number; blows: number }[];
+  thread?: string;
+  inGame: boolean;
+}
+
+const isValidCall = (call: number[]) => {
+  const numDict = Array<number>(10);
+  for (let i = 0; i < call.length; i++) {
+    if (numDict[call[i]] >= 1) {
+      return false;
+    }
+    numDict[call[i]] = 1;
+  }
+  return true;
+};
+
+const countHit = (call: number[], answer: number[]) => {
+  if (call.length !== answer.length) {
+    throw new Error('Length of the call does not match the answer.');
+  } else {
+    let count = 0;
+    for (let i = 0; i < call.length; i++) {
+      if (call[i] === answer[i]) {
+        count++;
+      }
+    }
+    return count;
+  }
+};
+
+// Hitも合わせて数える
+const countBlow = (call: number[], answer: number[]) => {
+  if (call.length !== answer.length) {
+    throw new Error('Length of the call does not match the answer.');
+  } else {
+    let count = 0;
+    const callArray = Array<number>(10);
+    const ansArray = Array<number>(10);
+    for (let i = 0; i < 10; i++) {
+      callArray[i] = ansArray[i] = 0;
+    }
+    for (let i = 0; i < call.length; i++) {
+      callArray[call[i]]++;
+      ansArray[answer[i]]++;
+    }
+    for (let i = 0; i < 10; i++) {
+      count += Math.min(callArray[i], ansArray[i]);
+    }
+    return count;
+  }
+};
+
+module.exports = (rtm: RTMClient, slack: WebClient) => {
+  const state: HitAndBlowState = {
+    answer: [],
+    history: [],
+    thread: undefined,
+    inGame: false,
+  };
+
+  // call履歴をpostする関数
+  const postHistory = async (
+    history: { call: number[]; hits: number; blows: number }[]
+  ) => {
+    if (history.length === 0) {
+      await slack.chat.postMessage({
+        text: 'コール履歴: なし',
+        channel: process.env.CHANNEL_SANDBOX as string,
+        username: 'Hit & Blow',
+        icon_emoji: '1234',
+        thread_ts: state.thread,
+      });
+    } else {
+      await slack.chat.postMessage({
+        text: stripIndent`
+      コール履歴: \`\`\`${history
+        .map(
+          (hist: { call: number[]; hits: number; blows: number }) =>
+            stripIndent`
+          ${hist.call.map((dig: number) => String(dig)).join('')}: ${
+              hist.hits
+            } Hit ${hist.blows} Blow`
+        )
+        .join('\n')}\`\`\`
+      `,
+        channel: process.env.CHANNEL_SANDBOX as string,
+        username: 'Hit & Blow',
+        icon_emoji: '1234',
+        thread_ts: state.thread,
+      });
+    }
+  };
+  rtm.on('message', async (message) => {
+    if (message.channel !== process.env.CHANNEL_SANDBOX) {
+      return;
+    }
+    if (message.subtype === 'bot_message') {
+      return;
+    }
+    if (!message.text) {
+      return;
+    }
+
+    // game開始処理
+    if (message.text.match(/^hitandblow( \d+)?$/)) {
+      if (state.inGame) {
+        await slack.chat.postMessage({
+          text: '進行中のゲームがあるよ:thinking_face:',
+          channel: process.env.CHANNEL_SANDBOX as string,
+          username: 'Hit & Blow',
+          icon_emoji: '1234',
+          thread_ts: state.thread,
+          reply_broadcast: true,
+        });
+        return;
+      } else {
+        const rawAnswerLength = message.text.match(/^hitandblow( \d+)?$/)[1];
+        const answerLength =
+          typeof rawAnswerLength !== 'undefined'
+            ? parseInt(rawAnswerLength)
+            : 4;
+        if (answerLength <= 0 || 10 < answerLength) {
+          await slack.chat.postMessage({
+            text: '桁数は1以上10以下で指定してね:thinking_face:',
+            channel: process.env.CHANNEL_SANDBOX as string,
+            username: 'Hit & Blow',
+            icon_emoji: '1234',
+          });
+        } else {
+          state.inGame = true;
+          state.answer = shuffle(range(10)).slice(0, answerLength);
+          const { ts } = await slack.chat.postMessage({
+            text: stripIndent`
+            Hit & Blow (${state.answer.length}桁) を開始します。
+            スレッドに「call hoge」とコールしてね`,
+            channel: process.env.CHANNEL_SANDBOX as string,
+            username: 'Hit & Blow',
+            icon_emoji: '1234',
+          });
+          state.thread = ts as string;
+          console.log(state.answer);
+        }
+      }
+    }
+
+    // call処理
+    if (message.text.match(/^call +\d+$/)) {
+      if (message.thread_ts !== state.thread) {
+        return;
+      } else {
+        if (!state.inGame) {
+          return;
+        }
+        const call = [
+          ...message.text.match(/^call +(\d+)$/)[1],
+        ].map((dig: string) => parseInt(dig));
+        if (call.length !== state.answer.length) {
+          await slack.chat.postMessage({
+            text: `桁数が違うよ:thinking_face: (${state.answer.length}桁)`,
+            channel: process.env.CHANNEL_SANDBOX as string,
+            username: 'Hit & Blow',
+            icon_emoji: '1234',
+            thread_ts: state.thread,
+          });
+        } else {
+          if (!isValidCall(call)) {
+            await slack.chat.postMessage({
+              text:
+                'call中に同じ数字を2個以上含めることはできないよ:thinking_face:',
+              channel: process.env.CHANNEL_SANDBOX as string,
+              username: 'Hit & Blow',
+              icon_emoji: '1234',
+              thread_ts: state.thread,
+            });
+          } else {
+            // validなcallの場合
+            const hits = countHit(call, state.answer);
+            const blows = countBlow(call, state.answer) - hits;
+            state.history.push({ call, hits, blows });
+            await slack.chat.postMessage({
+              text: `\`${call
+                .map((dig: number) => String(dig))
+                .join('')}\`: ${hits} Hit ${blows} Blow`,
+              channel: process.env.CHANNEL_SANDBOX as string,
+              username: 'Hit & Blow',
+              icon_emoji: '1234',
+              thread_ts: state.thread,
+            });
+            if (hits === state.answer.length) {
+              await slack.chat.postMessage({
+                text: stripIndent`
+                <@${message.user}> 正解です:tada:
+                答えは \`${state.answer
+                  .map((dig: number) => String(dig))
+                  .join('')}\` だよ:muscle:`,
+                channel: process.env.CHANNEL_SANDBOX as string,
+                username: 'Hit & Blow',
+                icon_emoji: '1234',
+                thread_ts: state.thread,
+                reply_broadcast: true,
+              });
+              postHistory(state.history);
+              state.answer = [];
+              state.history = [];
+              state.thread = undefined;
+              state.inGame = false;
+            }
+          }
+        }
+      }
+    }
+
+    // history処理
+    if (message.text.match(/^(history|コール履歴)$/)) {
+      if (message.thread_ts !== state.thread) {
+        return;
+      } else {
+        postHistory(state.history);
+      }
+    }
+  });
+};

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -230,7 +230,7 @@ export default ({
               if (state.answer.length >= 2 && state.history.length === 1) {
                 await unlock(
                   message.user,
-                  'hitandblow-clear-once-over-2digits'
+                  'hitandblow-clear-once-2digits-or-more'
                 );
               }
 

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -44,9 +44,6 @@ const countBlow = (call: number[], answer: number[]) => {
     const blows = new Set<number>();
     const callArray = Array<number>(10).fill(0);
     const ansArray = Array<number>(10).fill(0);
-    for (let i = 0; i < 10; i++) {
-      callArray[i] = ansArray[i] = 0;
-    }
     for (let i = 0; i < call.length; i++) {
       callArray[call[i]]++;
       ansArray[answer[i]]++;

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -12,7 +12,7 @@ interface HitAndBlowState {
 }
 
 const isValidCall = (call: number[]) => {
-  const numDict = Array<number>(10);
+  const numDict = Array<number>(10).fill(0);
   for (let i = 0; i < call.length; i++) {
     if (numDict[call[i]] >= 1) {
       return false;
@@ -42,8 +42,8 @@ const countBlow = (call: number[], answer: number[]) => {
     throw new Error('Length of the call does not match the answer.');
   } else {
     const blows = new Set<number>();
-    const callArray = Array<number>(10);
-    const ansArray = Array<number>(10);
+    const callArray = Array<number>(10).fill(0);
+    const ansArray = Array<number>(10).fill(0);
     for (let i = 0; i < 10; i++) {
       callArray[i] = ansArray[i] = 0;
     }

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -222,7 +222,7 @@ export default ({
               // 実績解除
               await unlock(message.user, 'hitandblow-clear');
               if (state.answer.length >= 6) {
-                await unlock(message.user, 'hitandblow-clear-over-6digits');
+                await unlock(message.user, 'hitandblow-clear-6digits-or-more');
               }
               if (state.answer.length === 10) {
                 await unlock(message.user, 'hitandblow-clear-10digits');

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ const allBots = [
 	'twitter-dm-notifier',
 	'tsgctf',
 	'jitsi',
+	'hitandblow',
 ];
 
 const argv = yargs


### PR DESCRIPTION
sandboxでHit & Blowができるとえらくない？えらいです（断定）

hitandblow {桁数(任意)}でHit & Blowを起動
スレッド内で{
数字をつぶやくとcall,
history/コール履歴 でcallの履歴を表示,
giveup/ギブアップ でギブアップ,
}
hbdiff {validなcall} {validなcall}（桁数が同じ）で２つのcallを比較してくれる

実績もいくつか追加