### PR TITLE
use qs parser in fasity-formbody

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const fastify = require('fastify')({
 const logger = require('./lib/logger.js');
 const yargs = require('yargs');
 
+const qs = require('qs');
 const fastifyFormbody = require('fastify-formbody');
 const fastifyExpress = require('fastify-express');
 
@@ -84,7 +85,9 @@ eventClient.on('error', (error) => {
 const messageClient = createMessageAdapter(process.env.SIGNING_SECRET);
 
 (async () => {
-	await fastify.register(fastifyFormbody);
+	// Specify qs parser for nested parsing
+	// See https://github.com/fastify/fastify-formbody/blob/v5.0.0/Readme.md#upgrading-from-4x
+	await fastify.register(fastifyFormbody, {parser: str => qs.parse(str)});
 	await fastify.register(fastifyExpress);
 
 	fastify.use('/slack-event', (req, res, next) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3033,6 +3033,11 @@
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
@@ -5991,6 +5996,13 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
       }
     },
     "ext-list": {
@@ -13312,9 +13324,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "query-string": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "opentype.js": "^1.3.3",
     "p-queue": "^6.6.1",
     "primes-and-factors": "^1.3.3",
+    "qs": "^6.9.4",
     "rouge": "github:kenlimmj/rouge",
     "scrape-it": "^5.2.4",
     "sharp": "^0.26.1",


### PR DESCRIPTION
https://github.com/tsg-ut/slackbot/commit/32de5592af93f3a8964a1adac16a69e851efc93c fastify-formbody v3.1.0 -> v5.0.0
このときを契機にmail-hookが壊れました。

* https://github.com/fastify/fastify-formbody/blob/v5.0.0/Readme.md#upgrading-from-4x
  > Previously, the external qs lib was used that did things like parse nested objects.
  > If you need nested parsing, you must configure it manually by installing the qs lib (npm i qs), and then configure an optional parser


* smtp2http
  https://github.com/tsg-ut/smtp2http/blob/5ea8d2717e689631b78c91b56f3197c5078258f1/handler.go#L52-L58

* mail-hook
  https://github.com/tsg-ut/slackbot/blob/60c7beca207a2ca402dabd4361b8f47b387e5788/mail-hook/index.js#L30