### PR TITLE
update google-tts-api 0.0.4 -> 0.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5061,14 +5061,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "encoding-japanese": {
       "version": "1.0.30",
       "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-1.0.30.tgz",
@@ -7083,11 +7075,11 @@
       }
     },
     "google-tts-api": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/google-tts-api/-/google-tts-api-0.0.4.tgz",
-      "integrity": "sha512-1fyRK4AxvtRrETxL59SwXgbY7cX3xhgOCbCaYu8BNlRZcjca0YeajA+50G7Jz3d6wpSxhxatz/lzMuomzWoNeQ==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/google-tts-api/-/google-tts-api-0.0.5.tgz",
+      "integrity": "sha512-hzZ2pMQpgXF/1LfD0I981O4+xdj4IJG5uO0KDHRWNLRAiIq6hPd7WYcbOQnHkyzGDaQVvk+Xnsc2jVfWDn2RGg==",
       "requires": {
-        "isomorphic-fetch": "^2.2.1"
+        "isomorphic-fetch": "^3.0.0"
       }
     },
     "googleapis": {
@@ -8112,23 +8104,12 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
       }
     },
     "isstream": {
@@ -15933,9 +15914,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-      "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "forever": "^3.0.2",
     "fs-extra": "^9.0.1",
     "gifwrap": "^0.9.2",
-    "google-tts-api": "^0.0.4",
+    "google-tts-api": "^0.0.5",
     "googleapis": "^60.0.1",
     "html-entities": "^1.3.1",
     "iconv-lite": "^0.6.2",


### PR DESCRIPTION
最近ボイパのテストが落ちていましたね

https://github.com/zlargon/google-tts/blob/master/CHANGELOG.md#005-nov-8-2020
> Add retry mechanism to prevent fetching token key failed too frequently. (# 33)
