### PR TITLE
README に GitHub Actions の status badge を追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: 
+on:
   - push
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # slackbot
 
-[![Build Status][travis-image]][travis-url]
+[![Test][action-image]][action-url]
 [![Coverage Status][codecov-image]][codecov-url]
 
 [![Coverage Graph][codecov-graph]][codecov-url]
 
-[travis-url]: https://travis-ci.org/tsg-ut/slackbot
-[travis-image]: https://travis-ci.org/tsg-ut/slackbot.svg?branch=master
+[action-url]: https://github.com/tsg-ut/slackbot/actions?query=workflow%3ATest
+[action-image]: https://github.com/tsg-ut/slackbot/workflows/Test/badge.svg
 [codecov-url]: https://codecov.io/gh/tsg-ut/slackbot
 [codecov-image]: https://codecov.io/gh/tsg-ut/slackbot/branch/master/graph/badge.svg
 [codecov-graph]: https://codecov.io/gh/tsg-ut/slackbot/branch/master/graphs/tree.svg?width=888&height=150


### PR DESCRIPTION
Close #365.

Travis を GitHub Actions に置き換えた。ついでに workflow のファイルのキモいスペースを消した。

これ、workflow 名が Test なの、開発途中のがそのままになってるのかと思いきや、ユニットテストの「テスト」なのね。ちょっとややこしい気もするけど、まあ。