### PR TITLE
ponpe: attachmentとかでstartsWithに出るエラー解消 #299

### DIFF
--- a/ponpe/index.ts
+++ b/ponpe/index.ts
@@ -86,7 +86,7 @@ export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
 	}
 	
 	rtm.on('message', async (message) => {
-		if(message.type !== 'message' || message.subtype === 'message_replied'){
+		if(!message.text || message.type !== 'message' || message.subtype === 'message_replied'){
 			return;
 		}
 		async function reply(msg:string):Promise<any>{


### PR DESCRIPTION
attachmentの時とかに`message.text`が`undefined`なのに`message.text.startsWith()`を呼んでいたため。