### PR TITLE
bcr: 実績一覧単体で反応

### DIFF
--- a/better-custom-response/custom-responses.ts
+++ b/better-custom-response/custom-responses.ts
@@ -11,12 +11,13 @@ interface Achievement {
 interface CustomResponse {
     input: RegExp[],
     outputArray?: string[],
-    outputFunction?: ((input: string[]) => string[] | Promise<string[]>),
+    outputFunction?: ((input: string[], user?: string) => string[] | Promise<string[]>),
     shuffle?: true,
     username?: string,
     icon_emoji?: string,
     reaction?: true,
-    achievements?: Achievement[],
+		achievements?: Achievement[],
+		needUsername?: true,
 }
 
 const customResponses: CustomResponse[] = [
@@ -70,7 +71,7 @@ const customResponses: CustomResponse[] = [
         input: [/^(.+)っちへ$/],
         outputFunction: input => [ stripIndent`
             ${input[1]}っちへ
-            
+
             ういっすー!
             朝から、完全にぽんぽんぺいんで、つらみが深いので、1日おふとんでスヤァしておきます。
             明日は行けたら行くマンです!` ],
@@ -89,7 +90,7 @@ const customResponses: CustomResponse[] = [
             もうまじ退職しか勝たんから
             明日からはおうちカフェで
             働くことにしました🐰
-            
+
             いままで397❤❤
             また会おーね👋😃` ],
         icon_emoji: ':shakaijin-ichinensei:',
@@ -153,6 +154,15 @@ const customResponses: CustomResponse[] = [
         },
         icon_emoji: ":achievement:",
         username: "実績一覧",
+    },
+    {
+        input: [/^実績一覧$/],
+        outputFunction: (input: string[], user: string) => {
+            return [`https://achievements.tsg.ne.jp/users/${user}`];
+        },
+        icon_emoji: ":achievement:",
+				username: "実績一覧",
+				needUsername: true,
     },
 ];
 

--- a/better-custom-response/custom-responses.ts
+++ b/better-custom-response/custom-responses.ts
@@ -16,8 +16,8 @@ interface CustomResponse {
     username?: string,
     icon_emoji?: string,
     reaction?: true,
-		achievements?: Achievement[],
-		needUsername?: true,
+    achievements?: Achievement[],
+    needsUsername?: true,
 }
 
 const customResponses: CustomResponse[] = [
@@ -71,7 +71,7 @@ const customResponses: CustomResponse[] = [
         input: [/^(.+)っちへ$/],
         outputFunction: input => [ stripIndent`
             ${input[1]}っちへ
-
+            
             ういっすー!
             朝から、完全にぽんぽんぺいんで、つらみが深いので、1日おふとんでスヤァしておきます。
             明日は行けたら行くマンです!` ],
@@ -161,8 +161,8 @@ const customResponses: CustomResponse[] = [
             return [`https://achievements.tsg.ne.jp/users/${user}`];
         },
         icon_emoji: ":achievement:",
-				username: "実績一覧",
-				needUsername: true,
+        username: "実績一覧",
+        needsUsername: true,
     },
 ];
 

--- a/better-custom-response/index.ts
+++ b/better-custom-response/index.ts
@@ -8,8 +8,8 @@ const response = async (text:string, user:string) => {
         for (const regexp of resp.input) {
             const matches = text.match(regexp);
             if (matches !== null) {
-							const responses = {}.hasOwnProperty.call(resp, 'outputArray') ? resp.outputArray :
-								(resp.needUsername ? await resp.outputFunction(matches, user) : await resp.outputFunction(matches));
+                const responses = {}.hasOwnProperty.call(resp, 'outputArray') ? resp.outputArray :
+                    (resp.needsUsername ? await resp.outputFunction(matches, user) : await resp.outputFunction(matches));
                 if (!responses) continue;
                 const respText = resp.shuffle ? shuffle(responses).join('') : sample(responses);
                 const respAchievements: string[] = [];

--- a/better-custom-response/index.ts
+++ b/better-custom-response/index.ts
@@ -3,12 +3,13 @@ import {sample, shuffle} from 'lodash';
 import type {SlackInterface} from '../lib/slack';
 const {unlock} = require('../achievements');
 
-const response = async (text:string) => {
+const response = async (text:string, user:string) => {
     for (const resp of customResponses.filter((response) => !response.reaction)) {
         for (const regexp of resp.input) {
             const matches = text.match(regexp);
             if (matches !== null) {
-                const responses = {}.hasOwnProperty.call(resp, 'outputArray') ? resp.outputArray : await resp.outputFunction(matches);
+							const responses = {}.hasOwnProperty.call(resp, 'outputArray') ? resp.outputArray :
+								(resp.needUsername ? await resp.outputFunction(matches, user) : await resp.outputFunction(matches));
                 if (!responses) continue;
                 const respText = resp.shuffle ? shuffle(responses).join('') : sample(responses);
                 const respAchievements: string[] = [];
@@ -48,7 +49,7 @@ export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
         if (!message.user || message.user.startsWith('B') || message.user === 'UEJTPN6R5' || message.user === 'USLACKBOT') return;
         const {channel, text, ts: timestamp} = message;
         if (!text) return;
-        const resp = await response(text);
+        const resp = await response(text, message.user);
         if (resp) {
             const username = !resp.username ? 'better-custom-response' : resp.username;
             const icon_emoji = !resp.icon_emoji ? ':slack:' : resp.icon_emoji;


### PR DESCRIPTION
「実績表示」単体で反応するようにしました。
- そのために`CustomResponse`インタフェースに`needUsername`を追加しました。