### PR TITLE
pwnyaa: 自己solve宣言

### DIFF
--- a/pwnyaa/.eslintrc.json
+++ b/pwnyaa/.eslintrc.json
@@ -14,7 +14,8 @@
 		"import/prefer-default-export": "off",
 		"camelcase": "off",
 		"max-params": "off",
-		"no-warning-comments": [2, { "terms": ["todo", "fixme", "xxx"], "location": "start" }]
+		"no-warning-comments": [2, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
+		"no-negated-condition": "off"
     },
     "settings": {
         "import/resolver": null

--- a/pwnyaa/index.ts
+++ b/pwnyaa/index.ts
@@ -514,7 +514,7 @@ export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
 		} else {
 			text += '今週のpwnランキングを発表するよ〜\n';
 			for (const [ix, user] of ranks.entries()) {
-				text += `*${ix + 1}* 位: <@${user.slackid}> \t\t*${user.solves}* solves \n`;
+				text += `*${ix + 1}* 位: *${await getMemberName(user.slackid)}* \t\t*${user.solves}* solves \n`;
 			}
 			text += '\nおめでとう〜〜〜〜〜〜〜〜 :genius:\n';
 		}

--- a/pwnyaa/index.ts
+++ b/pwnyaa/index.ts
@@ -487,7 +487,6 @@ export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
 	};
 
 	const postWeekly = async () => {
-		// for now, retrieve only TW.
 		let nobody = true;
 		const ranks: { slackid: string, solves: number }[] = [];
 		for (const contest of state.contests) {
@@ -495,13 +494,13 @@ export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
 			for (const user of users) {
 				const profile = await fetchUserProfile(user.idCtf, contest.id);
 				const recentSolves = filterChallSolvedRecent(profile.solvedChalls, 7);
-				if (ranks.some((rank) => rank.slackid === user.slackId)) {
-					const rankIndex = ranks.indexOf(ranks.find((rank) => rank.slackid === user.slackId));
-					ranks[rankIndex].solves += recentSolves.length;
-				} else {
-					ranks.push({slackid: user.slackId, solves: recentSolves.length});
-				}
-				if (recentSolves.length > 0) {
+				if (recentSolves.length > 0) {		// solved more than one challs
+					if (ranks.some((rank) => rank.slackid === user.slackId)) {
+						const rankIndex = ranks.indexOf(ranks.find((rank) => rank.slackid === user.slackId));
+						ranks[rankIndex].solves += recentSolves.length;
+					} else {
+						ranks.push({slackid: user.slackId, solves: recentSolves.length});
+					}
 					nobody = false;
 				}
 			}

--- a/pwnyaa/lib/BasicTypes.ts
+++ b/pwnyaa/lib/BasicTypes.ts
@@ -2,6 +2,7 @@
 export interface User {
   slackId: string,
   idCtf: string, // can be empty to represent only user itself
+  selfSolvesWeekly?: number,
 }
 
 // Site Information


### PR DESCRIPTION
以下の変更を行いました。
- `pwn`コマンドの追加: 常設CTF以外の問題を解いた際に、その旨を自己宣言することを可能にします。`pwn`コマンドで宣言したsolve数はweeklyのランキングに加算されます。
- usageの充実: コマンド毎のusageを`help <command name>`で見れるようにしました。
- 余分なメンションの廃止: 他のランキングに倣い、weeklyのランキングにおけるメンションを廃止しました。
- weeklyのランキングにおいて0-solveユーザを除外しました。