### PR TITLE
emodi help for filters

### DIFF
--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -452,7 +452,7 @@ interface Transformation {
 
 interface HelpRequest {
   kind: 'help';
-  argument: string
+  document: string
 }
 
 type ParseResult = Transformation | EmodiError | HelpRequest;
@@ -466,10 +466,14 @@ const parse = (message: string): ParseResult => {
   }
   if (parts[0] === 'help') {
     if (parts.length === 1) {
-      return {kind: 'help', argument: ''};
+      return {kind: 'help', document: ''};
     }
     if (parts.length === 2) {
-      return {kind: 'help', argument: parts[1]};
+      const document = helpDocs.get(parts[1]);
+      if (document === undefined) {
+        return {kind: 'help', document: 'No such filter, or no document for it'};
+      }
+      return {kind: 'help', document: document};
     }
     return parseError('too many argument');
   }

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -417,13 +417,6 @@ const filters: Map<string, Filter> = new Map([
 
 // help document {{{
 const helpDocs: Map<string, string> = new Map([
-  [
-    '',
-    'usage: <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n'
-      + 'Write ":" around the emoji name!\n\n'
-      + 'Filters:'
-      + [...filters.keys()].join(' ')
-  ],
   ['help', 'usage: help <filter>\nGet information about the given filter.'],
   // filters
   ['identity', 'usage: identity (no argument)\nMake no change.'],
@@ -466,7 +459,13 @@ const parse = (message: string): ParseResult => {
   }
   if (parts[0] === 'help') {
     if (parts.length === 1) {
-      return {kind: 'help', document: ''};
+      return {
+        kind: 'help',
+        document: 'usage: <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n'
+          + 'Write ":" around the emoji name!\n\n'
+          + 'Filters:'
+          + [...filters.keys()].join(' ')
+      };
     }
     if (parts.length === 2) {
       const document = helpDocs.get(parts[1]);

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -424,7 +424,7 @@ interface Transformation {
 
 interface HelpRequest {
   kind: 'help';
-  argument?: string
+  argument: string
 }
 
 type ParseResult = Transformation | EmodiError | HelpRequest;
@@ -438,7 +438,7 @@ const parse = (message: string): ParseResult => {
   }
   if (parts[0] === 'help') {
     if (parts.length === 1) {
-      return {kind: 'help'};
+      return {kind: 'help', argument: ''};
     }
     else if (parts.length === 2) {
       return {kind: 'help', argument: parts[1]};

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -461,7 +461,7 @@ const parse = (message: string): ParseResult => {
     if (parts.length > 1) {
       return parseError('filters cannot be applied to `help`');
     }
-    const subparts = parts[0].split(/\s+/); // split by serieses of spaces
+    const subparts = parts[0].split(/\s+/); // split by series of spaces
     if (subparts.length === 1) {
       return {
         kind: 'help',

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -455,7 +455,7 @@ const parse = (message: string): ParseResult => {
   const parts = message.split('|').map(_.trim);
   logger.info(parts);
   if (parts.length < 1) {
-    return parseError('Expected emoji; you can also type "@emodi help"');
+    return parseError('Expected emoji; you can also type `@emodi help`');
   }
   if (parts[0] === 'help' || parts[0].startsWith('help ')) {
     if (parts.length > 1) {

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -465,9 +465,9 @@ const parse = (message: string): ParseResult => {
     if (subparts.length === 1) {
       return {
         kind: 'help',
-        document: 'usage: <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n'
+        document: 'usage: @emodi <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n'
           + 'Write ":" around the emoji name!\n\n'
-          + 'Filters:'
+          + 'Filters: '
           + [...filters.keys()].join(' ')
       };
     }

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -468,7 +468,7 @@ const parse = (message: string): ParseResult => {
         document: 'usage: @emodi <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n' +
           'Write ":" around the emoji name!\n\n' +
           'Filters: ' +
-          [...filters.keys()].join(' ')
+          [...filters.keys()].join(' '),
       };
     }
     if (subparts.length === 2) {

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -476,7 +476,7 @@ const parse = (message: string): ParseResult => {
       if (document === undefined) {
         return {kind: 'help', document: 'No such filter, or no document for it'};
       }
-      return {kind: 'help', document: document};
+      return {kind: 'help', document};
     }
     return parseError('too many argument');
   }

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -458,7 +458,11 @@ const parse = (message: string): ParseResult => {
     return parseError('Expected emoji; you can also type "@emodi help"');
   }
   if (parts[0] === 'help') {
-    if (parts.length === 1) {
+    if (parts.length > 1) {
+      return parseError('filters cannot be applied to `help`');
+    }
+    const subparts = parts[0].split(/\s+/) // split by serieses of spaces
+    if (subparts.length === 1) {
       return {
         kind: 'help',
         document: 'usage: <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n'
@@ -467,7 +471,7 @@ const parse = (message: string): ParseResult => {
           + [...filters.keys()].join(' ')
       };
     }
-    if (parts.length === 2) {
+    if (subparts.length === 2) {
       const document = helpDocs.get(parts[1]);
       if (document === undefined) {
         return {kind: 'help', document: 'No such filter, or no document for it'};

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -589,17 +589,12 @@ export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
       text: message,
     });
   };
-  const postHelp = (): void => {
+  const postHelp = (document: string): void => {
     slack.chat.postMessage({
       channel: process.env.CHANNEL_SANDBOX,
       username: 'emoji-modifier',
       icon_emoji: ':essential-information:',
-      text: [...filters.entries()].map(([name, filter]: [string, Filter]): string => {
-        if (filter.arguments.length === 0) {
-          return name;
-        }
-        return name + ' ' + filter.arguments.map((s: string) => '[' + s + ']').join(' ');
-      }).join('\n'),
+      text: document,
     });
   };
 
@@ -624,7 +619,7 @@ export default async ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
       postError(result.message);
     }
     else if (result.kind === 'help') {
-      postHelp();
+      postHelp(result.document);
     }
     else {
       const url = await uploadEmoji(result);

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -422,6 +422,7 @@ const helpDocs: Map<string, string> = new Map([
     'usage: <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n'
       + 'Write ":" around the emoji name!\n\n'
       + 'Filters:'
+      + [...filters.keys()].join(' ')
   ],
   ['help', 'usage: help <filter>\nGet information about the given filter.'],
   // filters

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -466,8 +466,8 @@ const parse = (message: string): ParseResult => {
       return {
         kind: 'help',
         document: 'usage: @emodi <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n' +
-          'Write ":" around the emoji name!\n\n'
-          + 'Filters: ' +
+          'Write ":" around the emoji name!\n\n' +
+          'Filters: ' +
           [...filters.keys()].join(' ')
       };
     }

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -457,7 +457,7 @@ const parse = (message: string): ParseResult => {
   if (parts.length < 1) {
     return parseError('Expected emoji; you can also type "@emodi help"');
   }
-  if (parts[0] === 'help') {
+  if (parts[0] === 'help' || parts[0].startsWith('help ')) {
     if (parts.length > 1) {
       return parseError('filters cannot be applied to `help`');
     }
@@ -472,7 +472,7 @@ const parse = (message: string): ParseResult => {
       };
     }
     if (subparts.length === 2) {
-      const document = helpDocs.get(parts[1]);
+      const document = helpDocs.get(subparts[1]);
       if (document === undefined) {
         return {kind: 'help', document: 'No such filter, or no document for it'};
       }

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -415,6 +415,32 @@ const filters: Map<string, Filter> = new Map([
 ] as [string, Filter][]);
 // }}}
 
+// help document {{{
+const helpDocs: Map<string, string> = new Map([
+  [
+    '',
+    'usage: <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n'
+      + 'Write ":" around the emoji name!'
+  ],
+  ['help', 'usage: help <filter>\nGet information about the given filter.'],
+  // filters
+  ['identity', 'usage: identity (no argument)\nMake no change.'],
+  ['speedTimes', 'usage: speedtimes <number>\nChange the speed of animation.'],
+  ['mirrorV', 'usage: mirrorV (no argument)\nReflect the emoji through the horizontal median line.'],
+  ['mirror', 'usage: mirror (no argument)\nReflect the emoji through the vertical median line.'],
+  [
+    'move',
+    'usage: move <"top"|"bottom"|"left"|"right"> <"top"|"bottom"|"left"|"right">\n'
+      + 'Move the emoji so that it comes in from the side specified by the first argument and goes out through the side specified by the second argument.'
+  ],
+  ['go', 'usage: move <"top"|"bottom"|"left"|"right">\nMove the emoji in the given direction.'],
+  ['trim', 'usage: trim <number>\nTrim the emoji including the opaque pixels with regard to the given threshold.'],
+  ['distort', 'usage: distort (no argument)\nDistort the emoji.'],
+  ['pro', 'usage: pro <string> <string>\nCreate a fake proof that somebody of the emoji avatar with the given username and user_id said "私がプロだ" on an SNS.'],
+  ['think', 'usage: think (no argument)\nAttach a hand to the emoji as if it is thinking.'],
+]);
+// }}}
+
 // parsing & executing {{{
 interface Transformation {
   kind: 'success';

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -425,8 +425,8 @@ const helpDocs: Map<string, string> = new Map([
   ['mirror', 'usage: mirror (no argument)\nReflect the emoji through the vertical median line.'],
   [
     'move',
-    'usage: move <"top"|"bottom"|"left"|"right"> <"top"|"bottom"|"left"|"right">\n'
-      + 'Move the emoji so that it comes in from the side specified by the first argument and goes out through the side specified by the second argument.'
+    'usage: move <"top"|"bottom"|"left"|"right"> <"top"|"bottom"|"left"|"right">\n' +
+      'Move the emoji so that it comes in from the side specified by the first argument and goes out through the side specified by the second argument.'
   ],
   ['go', 'usage: move <"top"|"bottom"|"left"|"right">\nMove the emoji in the given direction.'],
   ['trim', 'usage: trim <number>\nTrim the emoji including the opaque pixels with regard to the given threshold.'],

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -424,6 +424,7 @@ interface Transformation {
 
 interface HelpRequest {
   kind: 'help';
+  argument?: string
 }
 
 type ParseResult = Transformation | EmodiError | HelpRequest;
@@ -433,13 +434,18 @@ const parse = (message: string): ParseResult => {
   const parts = message.split('|').map(_.trim);
   logger.info(parts);
   if (parts.length < 1) {
-    return parseError('Expected emoji');
+    return parseError('Expected emoji; you can also type "@emodi help"');
   }
   if (parts[0] === 'help') {
-    if (parts.length > 1) {
-      return parseError('`help` needs no argument');
+    if (parts.length === 1) {
+      return {kind: 'help'};
     }
-    return {kind: 'help'};
+    else if (parts.length === 2) {
+      return {kind: 'help', argument: parts[1]};
+    }
+    else {
+      return parseError('too many argument');
+    }
   }
   const nameMatch = /^:(?<name>[^!:\s]+):$/.exec(parts[0]);
   if (nameMatch == null) {

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -467,8 +467,8 @@ const parse = (message: string): ParseResult => {
         kind: 'help',
         document: 'usage: @emodi <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n' +
           'Write ":" around the emoji name!\n\n'
-          + 'Filters: '
-          + [...filters.keys()].join(' ')
+          + 'Filters: ' +
+          [...filters.keys()].join(' ')
       };
     }
     if (subparts.length === 2) {

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -474,7 +474,8 @@ const parse = (message: string): ParseResult => {
     if (subparts.length === 2) {
       const document = helpDocs.get(subparts[1]);
       if (document === undefined) {
-        return {kind: 'help', document: 'No such filter, or no document for it'};
+        const helpArgumentError = errorOfKind('HelpArgumentError')
+        return helpArgumentError('No such filter, or no document for it');
       }
       return {kind: 'help', document};
     }

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -461,7 +461,7 @@ const parse = (message: string): ParseResult => {
     if (parts.length > 1) {
       return parseError('filters cannot be applied to `help`');
     }
-    const subparts = parts[0].split(/\s+/) // split by serieses of spaces
+    const subparts = parts[0].split(/\s+/); // split by serieses of spaces
     if (subparts.length === 1) {
       return {
         kind: 'help',

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -420,7 +420,8 @@ const helpDocs: Map<string, string> = new Map([
   [
     '',
     'usage: <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n'
-      + 'Write ":" around the emoji name!'
+      + 'Write ":" around the emoji name!\n\n'
+      + 'Filters:'
   ],
   ['help', 'usage: help <filter>\nGet information about the given filter.'],
   // filters

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -426,7 +426,7 @@ const helpDocs: Map<string, string> = new Map([
   [
     'move',
     'usage: move <"top"|"bottom"|"left"|"right"> <"top"|"bottom"|"left"|"right">\n' +
-      'Move the emoji so that it comes in from the side specified by the first argument and goes out through the side specified by the second argument.'
+      'Move the emoji so that it comes in from the side specified by the first argument and goes out through the side specified by the second argument.',
   ],
   ['go', 'usage: move <"top"|"bottom"|"left"|"right">\nMove the emoji in the given direction.'],
   ['trim', 'usage: trim <number>\nTrim the emoji including the opaque pixels with regard to the given threshold.'],

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -440,12 +440,10 @@ const parse = (message: string): ParseResult => {
     if (parts.length === 1) {
       return {kind: 'help', argument: ''};
     }
-    else if (parts.length === 2) {
+    if (parts.length === 2) {
       return {kind: 'help', argument: parts[1]};
     }
-    else {
-      return parseError('too many argument');
-    }
+    return parseError('too many argument');
   }
   const nameMatch = /^:(?<name>[^!:\s]+):$/.exec(parts[0]);
   if (nameMatch == null) {

--- a/emoji-modifier/index.ts
+++ b/emoji-modifier/index.ts
@@ -465,8 +465,8 @@ const parse = (message: string): ParseResult => {
     if (subparts.length === 1) {
       return {
         kind: 'help',
-        document: 'usage: @emodi <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n'
-          + 'Write ":" around the emoji name!\n\n'
+        document: 'usage: @emodi <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...\n' +
+          'Write ":" around the emoji name!\n\n'
           + 'Filters: '
           + [...filters.keys()].join(' ')
       };


### PR DESCRIPTION
Help documents for each filter is now on.
e.g. Post `@emodi help move` and you will get the information about the `move` filter.

The normal help message is also improved. Post `@emodi help` and you will get
>usage: @emodi <emoji> | <filter> <argument> <argument> ... | <filter> <argument> <argument> ... | ...
>Write ":" around the emoji name!
>Filters: identity speedTimes mirrorV mirror move go trim distort pro think

_Semi-destructive change: every time you implement a new filter from now on, you should add its help document, although no fatal error will happen even if you don’t do that._