### PR TITLE
pwnyaa: ksnctf用に実績を追加

### DIFF
--- a/achievements/achievements.ts
+++ b/achievements/achievements.ts
@@ -1964,6 +1964,20 @@ const achievements: Achievement[] = [
 		condition: 'cryptohackを全完する',
 		category: 'pwnyaa',
 	},
+	{
+		id: 'pwnyaa-ksn-half',
+		difficulty: 'medium',
+		title: 'ニルギリ!',
+		condition: 'ksnctfで半分以上の問題を解く',
+		category: 'pwnyaa',
+	},
+	{
+		id: 'pwnyaa-ksn-complete',
+		difficulty: 'hard',
+		title: '村人Aには会えましたか...?',
+		condition: 'ksnctfを全完する',
+		category: 'pwnyaa',
+	},
 
 	// anime
 


### PR DESCRIPTION
pwnyaaをksnCTFに対応するに際して、専用の実績を2つ追加したいです。