### PR TITLE
lint スクリプトの改善

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "nodemon --exitcrash --watch .restart-trigger -x ts-node index.ts",
     "dev": "nodemon -x ts-node -e js,ts index.ts -i \"*.json\"",
-    "lint": "sed \"s/\\/.\\+//g\" CODEOWNERS | grep \"^[a-z]\" | awk '{print $1}' | xargs -n 1 npx eslint --ext js,ts",
+    "lint": "sed \"s/\\/.\\+//g\" CODEOWNERS | grep \"^[a-z]\" | awk '{print $1}' | xargs -n 1 eslint --ext js,ts",
     "fix": "npm run lint -- --fix",
     "test": "jest --verbose --coverage"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "nodemon --exitcrash --watch .restart-trigger -x ts-node index.ts",
     "dev": "nodemon -x ts-node -e js,ts index.ts -i \"*.json\"",
-    "lint": "sed \"s/\\/.\\+//g\" CODEOWNERS | grep \"^[a-z]\" | xargs -n 1 eslint --ext js,ts",
+    "lint": "sed \"s/\\/.\\+//g\" CODEOWNERS | grep \"^[a-z]\" | awk '{print $1}' | xargs -n 1 npx eslint --ext js,ts",
     "fix": "npm run lint -- --fix",
     "test": "jest --verbose --coverage"
   },


### PR DESCRIPTION
従来の CODEOWNERS の読み方では、無駄な lint 試行が発生していました。
例えば、 `sed "s/\\/.\\+//g" CODEOWNERS | grep "^[a-z]" | xargs -n 1 echo` してみると
```
achievements/**
@hakatashi
ahokusa/**
@kurgm
anime/**
@hakatashi
...
```
となります。つまり2行に1行、invalid な入力が lint に渡されていたわけで、そのたびに
```
Oops! Something went wrong! :(

ESLint: 7.18.0

No files matching the pattern "@hakatashi" were found.
Please check for typing mistakes in the pattern.
```
などと言われていました。

この PR では、awk を挟むことによってこれを修正しています。

参考: `sed "s/\\/.\\+//g" CODEOWNERS | grep "^[a-z]" | awk '{print $1}' | xargs -n 1 echo`
```
achievements/**
ahokusa/**
anime/**
...
```