### PR TITLE
amongyou: fix #447 and other time-related features

### DIFF
--- a/amongyou/index.ts
+++ b/amongyou/index.ts
@@ -13,7 +13,7 @@ import {getMemberIcon, getMemberName} from '../lib/slackUtils';
 import {Deferred} from '../lib/utils';
 
 const CALLME = '@amongyou';
-const AMONGABLE_CHECK_INTERVAL = 10 * 60 * 1000;
+const AMONGABLE_CHECK_INTERVAL = 60 *1000;
 
 const timeList = () => {
 	const isOver30 = moment().minutes() >= 30;

--- a/amongyou/index.ts
+++ b/amongyou/index.ts
@@ -234,34 +234,6 @@ class Among {
 			if (this.state.activeChannel === null) {
 				return;
 			}
-			if (!this.checkValidity(payload.user.id)) {
-				console.log(payload);
-				return {
-					response_action: 'push',
-					view: {
-						type: 'modal',
-						callback_id: 'second_step_callback_id',
-						title: {
-							type: 'plain_text',
-							text: 'Second step',
-						},
-						blocks: [
-							{
-								type: 'input',
-								block_id: 'last_thing',
-								element: {
-									type: 'plain_text_input',
-									action_id: 'text',
-								},
-								label: {
-									type: 'plain_text',
-									text: 'One last thing...',
-								},
-							},
-						],
-					},
-				};
-			}
 			this.joinUser(payload.user.id);
 			this.slack.chat.update({
 				channel: this.state.activeChannel,
@@ -556,11 +528,11 @@ class Among {
 	async joinUser(slackid: string) {
 		const targetix = this.state.tmpUsers.findIndex((user) => user.slackId === slackid);
 		if (targetix === -1) {
-			return false;
+			return;
 		}
 		// eslint-disable-next-line max-len
 		if (this.state.tmpUsers[targetix].people === null || this.state.tmpUsers[targetix].timeStart === null || this.state.tmpUsers[targetix].timeEnd === null) {
-			return false;
+			return;
 		}
 		if (this.state.users.some((user) => user.slackId === slackid)) {
 			this.setState({
@@ -575,7 +547,6 @@ class Among {
 				users: this.state.users.concat([this.state.tmpUsers[targetix]]),
 			} as State);
 		}
-		return true;
 	}
 
 	cancelUser(slackid: string) {

--- a/amongyou/index.ts
+++ b/amongyou/index.ts
@@ -33,7 +33,6 @@ const numList = [
 
 export interface User{
 	slackId: string,
-	probability: number,
 	timeStart: Date | null,
 	timeEnd: Date | null,
 	people: number | null,
@@ -412,7 +411,6 @@ class Among {
 				text: stripIndent`
 					${user.people}人   ${printableDate(user.timeStart)} ~ ${printableDate(user.timeEnd)}
 				`,
-				footer: `確度 ${user.probability}`,
 			});
 		}
 		return attachments;
@@ -490,7 +488,6 @@ class Among {
 				timeEnd: null,
 				slackId: slackid,
 				people: null,
-				probability: 100,
 			});
 			this.setState(this.state);
 		}
@@ -516,7 +513,6 @@ class Among {
 				timeEnd: date,
 				slackId: slackid,
 				people: null,
-				probability: 100,
 			});
 			this.setState(this.state);
 		}
@@ -539,7 +535,6 @@ class Among {
 				timeEnd: null,
 				slackId: slackid,
 				people: num,
-				probability: 100,
 			});
 			this.setState(this.state);
 		}


### PR DESCRIPTION
amongyouで時間関係の諸々を修正します。
- :bug: 現在時刻が30分を過ぎている場合の提示選択肢の修正
- :sparkles: 開催可否の判定で、募集開始時からの経過時間でカウントしていたのを、開催中は毎分判定
- :fire: 確度の概念を抹消

resolve #447 