### PR TITLE
hangman: fix #469: clear user info when the difficulty is invalid

### DIFF
--- a/hangman/index.js
+++ b/hangman/index.js
@@ -273,6 +273,9 @@ module.exports = ({ rtmClient: rtm, webClient: slack }) => {
                 const difficultyString = ((matches[1] === "") ? "medium" : matches[1].slice(1));
                 if (!difficultyString.match(/easy|medium|hard|extreme/)) {
                     await postMessage('難易度はeasy/medium/hard/extremeのどれかを指定してね');
+                    delete state[message.user];
+                    setState(state, state);
+
                     return;
                 }
 


### PR DESCRIPTION
User information is stored in `state.json` when user issues `hangman .+` command. When the specified difficulty is invalid, the information is still `state.json` and block the user.  
This commit clears the info when the difficulty is invalid.

fix #469 