### PR TITLE
たほいやのブロックをなくす

### DIFF
--- a/tahoiya/index.js
+++ b/tahoiya/index.js
@@ -39,6 +39,7 @@ const {
 
 const timeCollectMeaningNormal = 3 * 60 * 1000;
 const timeCollectMeaningDaily = 90 * 60 * 1000;
+const timeCollectBettingNormal = 3 * 60 * 1000;
 const timeCollectBettingDaily = 30 * 60 * 1000;
 const timeExtraAddition = 60 * 1000;
 
@@ -697,7 +698,7 @@ module.exports = async ({rtmClient: rtm, webClient: slack}) => {
 	const startDaily = async () => {
 		assert(state.phase === 'waiting');
 
-		const end = Date.now() + 90 * 60 * 1000;
+		const end = Date.now() + timeCollectMeaningDaily;
 		await setState({
 			phase: 'collect_meanings',
 			isWaitingDaily: false,

--- a/tahoiya/index.js
+++ b/tahoiya/index.js
@@ -53,11 +53,11 @@ module.exports = async ({rtmClient: rtm, webClient: slack}) => {
 		try {
 			// eslint-disable-next-line global-require
 			const savedState = require('./state.json');
-			if (savedState.endThisPhase != null) {
+			if (savedState.endThisPhase !== null) {
 				assert(savedState.phase !== 'waiting');
 				const difftime = savedState.endThisPhase - Date.now();
 				if (difftime <= 0) {
-					logger.info("tahoiya ends its phase while deploy, hence add extra time");
+					logger.info('tahoiya ends its phase while deploy, hence add extra time');
 					savedState.endThisPhase = Date.now() + timeExtraAddition;
 				}
 				switch (savedState.phase) {
@@ -87,7 +87,7 @@ module.exports = async ({rtmClient: rtm, webClient: slack}) => {
 				stashedDaily: savedState.stashedDaily || null,
 				endThisPhase: savedState.endThisPhase || null,
 			};
-		} catch (e) {
+		} catch (error) {
 			return {
 				phase: 'waiting',
 				isWaitingDaily: false,
@@ -412,7 +412,7 @@ module.exports = async ({rtmClient: rtm, webClient: slack}) => {
 				}
 			}
 		}
-	};
+	}
 
 	async function onFinishBettings() {
 		assert(state.phase === 'collect_bettings');
@@ -676,7 +676,7 @@ module.exports = async ({rtmClient: rtm, webClient: slack}) => {
 				await unlock(user, 'tahoiya-deceive3');
 			}
 		}
-	};
+	}
 
 	const onBotResult = async ({result, modelName}) => {
 		assert(state.phase === 'collect_meanings');

--- a/tahoiya/index.js
+++ b/tahoiya/index.js
@@ -49,7 +49,7 @@ const queue = new Queue({concurrency: 1});
 const transaction = (func) => queue.add(func);
 
 module.exports = async ({rtmClient: rtm, webClient: slack}) => {
-const state = (() => {
+	const state = (() => {
 		try {
 			// eslint-disable-next-line global-require
 			const savedState = require('./state.json');

--- a/tahoiya/initdb.sql
+++ b/tahoiya/initdb.sql
@@ -1,0 +1,10 @@
+create table themes(
+  user TEXT PRIMARY KEY,
+  word TEXT NOT NULL,
+  ruby TEXT NOT NULL,
+  meaning TEXT NOT NULL,
+  source TEXT NOT NULL,
+  url TEXT NOT NULL,
+  ts INTEGER,
+  done INTEGER
+);


### PR DESCRIPTION
たほいやのデプロイブロックをなくしたいです。
  
各状態のときには以下のように処理をします。
- `waiting`: 追加処理なし
- `collect_meanings`, `collect_bettings`: フェーズ終了時間を追加で`state.json`に追加します。再起動後は、`collect_meanings`/`collect_bettings`状態ならば`setTimeout`を再び設定します。デプロイ中にフェーズの終了時刻を終了してしまったときには、`timeExtraAddition`時間だけ追加でフェーズを続けます。


resolves #472 