### PR TITLE
Disable tiobot outside sandbox

### DIFF
--- a/tiobot/index.ts
+++ b/tiobot/index.ts
@@ -9,6 +9,10 @@ export default ({rtmClient: rtm, webClient: slack}: SlackInterface) => {
 			return;
 		}
 
+		if (message.channel !== process.env.CHANNEL_SANDBOX) {
+			return;
+		}
+
 		const {text} = message;
 		let matches: String[] = null;
 


### PR DESCRIPTION
ライブコードゴルフ大会の企画中、planner チャンネルに貼った tio のコードが sandbox に流出するということがありました。