### PR TITLE
[fix]太字インジェクションにある程度対応した

### DIFF
--- a/better-custom-response/custom-responses.ts
+++ b/better-custom-response/custom-responses.ts
@@ -203,7 +203,7 @@ const customResponses: CustomResponse[] = [
                 return stripIndent`\
                 :meishodoto_umamusume: 「救いは無いのですか～？」
                 :matikanefukukitaru_umamusume: 「むむっ…　:palms_up_together::crystal_ball:」
-                :matikanefukukitaru_umamusume: 「出ました！　『＊${c}＊』です！」
+                :matikanefukukitaru_umamusume: 「出ました！　＊『${c.trim()}』＊です！」
                 `;
             }
             return choice.map(fukukitarify);


### PR DESCRIPTION
＊～＊を『』の外側に置くことで、表示が壊れない場合を増やした（絶対に壊さないのはむずかしそう…）