### PR TITLE
pwnyaa: fix bug of parse TW's CSRFTOKEN

### DIFF
--- a/pwnyaa/lib/TWManager.ts
+++ b/pwnyaa/lib/TWManager.ts
@@ -89,7 +89,8 @@ const parseProfileTW = async (html: any) => {
 
 const getCsrfsTW = (res: AxiosResponse) => {
 	const html = res.data;
-	const candMiddle = html.match((/ {3}<input type='hidden' name='csrfmiddlewaretoken' value='([A-Za-z0-9]+)' \/>/))[1];
+	console.log(html);
+	const candMiddle = html.match((/<input type="hidden" name="csrfmiddlewaretoken" value="([A-Za-z0-9]+)">/))[1];
 	csrfmiddlewaretokenTW = candMiddle ? candMiddle : csrfmiddlewaretokenTW;
 
 	const candCsrf = String(res.headers['set-cookie']).split(' ')[0];

--- a/pwnyaa/lib/TWManager.ts
+++ b/pwnyaa/lib/TWManager.ts
@@ -89,7 +89,6 @@ const parseProfileTW = async (html: any) => {
 
 const getCsrfsTW = (res: AxiosResponse) => {
 	const html = res.data;
-	console.log(html);
 	const candMiddle = html.match((/<input type="hidden" name="csrfmiddlewaretoken" value="([A-Za-z0-9]+)">/))[1];
 	csrfmiddlewaretokenTW = candMiddle ? candMiddle : csrfmiddlewaretokenTW;
 


### PR DESCRIPTION
- TW's csrf token format changed.
 - input tag changed from `<input .../>` to `<input ...>`
 - single quort became double quorts