### PR TITLE
Throttle updates of the loading message

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,7 @@ import fastifyExpress from 'fastify-express';
 
 import sharp from 'sharp';
 
-import { throttle } from 'lodash';
+import {throttle} from 'lodash';
 
 // Disable the cache since it likely hits the swap anyway
 sharp.cache(false);

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,3 @@
-import { throttle } from 'lodash';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -20,6 +19,8 @@ import fastifyFormbody from 'fastify-formbody';
 import fastifyExpress from 'fastify-express';
 
 import sharp from 'sharp';
+
+import { throttle } from 'lodash';
 
 // Disable the cache since it likely hits the swap anyway
 sharp.cache(false);

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import { throttle } from 'lodash';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -124,7 +125,7 @@ const messageClient = createMessageAdapter(process.env.SIGNING_SECRET);
 
 	const loadedPlugins = new Set<string>();
 
-	const initializationMessagePromise = webClient.chat.postMessage({
+	const initializationMessage = await webClient.chat.postMessage({
 		username: `tsgbot [${os.hostname()}]`,
 		channel: process.env.CHANNEL_SANDBOX,
 		text: `起動中⋯⋯ (${loadedPlugins.size}/${plugins.length})`,
@@ -134,21 +135,7 @@ const messageClient = createMessageAdapter(process.env.SIGNING_SECRET);
 		})),
 	});
 
-	await Promise.all(plugins.map(async (name) => {
-		const plugin = await import(`./${name}`);
-		if (typeof plugin === 'function') {
-			await plugin({rtmClient, webClient, eventClient, messageClient});
-		}
-		if (typeof plugin.default === 'function') {
-			await plugin.default({rtmClient, webClient, eventClient, messageClient});
-		}
-		if (typeof plugin.server === 'function') {
-			await fastify.register(plugin.server({rtmClient, webClient, eventClient, messageClient}));
-		}
-		loadedPlugins.add(name);
-		logger.info(`plugin "${name}" successfully loaded`);
-
-		const initializationMessage = await initializationMessagePromise;
+	const throttleLoadingMessageUpdate = throttle(() => {
 		webClient.chat.update({
 			channel: process.env.CHANNEL_SANDBOX,
 			ts: initializationMessage.ts as string,
@@ -164,6 +151,23 @@ const messageClient = createMessageAdapter(process.env.SIGNING_SECRET);
 				})),
 			],
 		})
+	}, 0.5 * 1000);
+
+	await Promise.all(plugins.map(async (name) => {
+		const plugin = await import(`./${name}`);
+		if (typeof plugin === 'function') {
+			await plugin({rtmClient, webClient, eventClient, messageClient});
+		}
+		if (typeof plugin.default === 'function') {
+			await plugin.default({rtmClient, webClient, eventClient, messageClient});
+		}
+		if (typeof plugin.server === 'function') {
+			await fastify.register(plugin.server({rtmClient, webClient, eventClient, messageClient}));
+		}
+		loadedPlugins.add(name);
+		logger.info(`plugin "${name}" successfully loaded`);
+
+		throttleLoadingMessageUpdate();
 	}));
 
 	logger.info('Launched');


### PR DESCRIPTION
`tahoiya`（通常最後にロードされる）が`loading`表示から`loaded`表示に切り替わらないまま起動が完了することがあるというバグ #506 の原因は、メッセージの更新が同期的に行われるためにその順序が逆転してしまう場合があることとみられます。そこで`lodash`の`throttle`を用いることでメッセージの更新を0.5秒に1回に制限しました。
あわせて、ロードの開始を初期メッセージの投稿が終わるのを待ってからにしました。こうしないと代わりに`throttle`内でawaitをすることになり好ましくないためです。
手元にslackbotに必要な資源を全て揃えることができなかったため完全なデバッグはできていません。

The occasional bug #506 where the loading message ceases to update saying that `tahoiya` plugin, which is usually the last one loaded, is still "loading" instead of "loaded" probably happens when the order of message updates is reversed because they are done synchronously. I use `lodash`'s `throttle` to limit the frequency of message updates to once every 0.5 second.
In addition, I programmed so that the loading process starts after awaiting the initial loading message to be posted. Otherwise I would have to do an `await` in the throttled process instead, which is not preferable.
I haven't been able to debug it completely because I didn't have all the resources necessary for slackbot on my computer.