### PR TITLE
Fix #425: ignore duplicates in the argument array `--only`.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -97,7 +97,7 @@ const argv = yargs
 const plugins = uniq(argv.only);
 
 if (plugins.length !== argv.only.length) {
-	logger.info(`Some plugins are specified more than once. Ignore except the first for each.`)
+	logger.info(`Some plugins are specified more than once. Duplicated plugins were removed.`)
 }
 
 const eventClient = createEventAdapter(process.env.SIGNING_SECRET);

--- a/index.ts
+++ b/index.ts
@@ -95,6 +95,11 @@ const argv = yargs
 	.argv;
 
 const plugins = uniq(argv.only);
+
+if (plugins.length !== argv.only.length) {
+	logger.info(`Some plugins are specified more than once. Ignore except the first for each.`)
+}
+
 const eventClient = createEventAdapter(process.env.SIGNING_SECRET);
 eventClient.on('error', (error) => {
 	logger.error(error.stack);

--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,7 @@ import fastifyExpress from 'fastify-express';
 
 import sharp from 'sharp';
 
-import {throttle} from 'lodash';
+import {uniq, throttle} from 'lodash';
 
 // Disable the cache since it likely hits the swap anyway
 sharp.cache(false);
@@ -94,7 +94,7 @@ const argv = yargs
 	.default('startup', 'ｼｭｯｼｭｯ (起動音)')
 	.argv;
 
-const plugins = argv.only;
+const plugins = uniq(argv.only);
 const eventClient = createEventAdapter(process.env.SIGNING_SECRET);
 eventClient.on('error', (error) => {
 	logger.error(error.stack);


### PR DESCRIPTION
Ignore duplicates in the argument array `--only` (but give notice).

For example, this change affects the result of the following command:
```
npm run dev -- --only deploy --only deploy
```
Previously it was an error. After this change, it successfully loads the `deploy` plugin only once, showing
```
[INFO] HH:MM:SS Some plugins are specified more than once. Ignore except the first for each.
```

Fixed #425.