### PR TITLE
再接続通知を削除

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -185,28 +185,7 @@ const messageClient = createMessageAdapter(process.env.SIGNING_SECRET);
 		text: argv.startup,
 	});
 
-	let firstLogin = true;
-	let lastLogin: number = null;
-	let combos = 1;
 	rtmClient.on('authenticated', (data) => {
 		logger.info(`Logged in as ${data.self.name} of team ${data.team.name}`);
-		const now = Date.now();
-		if (!firstLogin) {
-			let comboStr = '';
-			if (now - lastLogin <= 2 * 60 * 1000) {
-				combos++;
-				comboStr = `(${combos}コンボ${'!'.repeat(combos)})`
-			}
-			else {
-				combos = 1;
-			}
-			webClient.chat.postMessage({
-				username: `tsgbot [${os.hostname()}]`,
-				channel: process.env.CHANNEL_SANDBOX,
-				text: `再接続しました ${comboStr}`,
-			});
-		}
-		firstLogin = false;
-		lastLogin = now;
 	});
 })();


### PR DESCRIPTION
再接続通知がデバッグに有用であることが少ない一方で、その投稿の頻度は低くありません。

sandboxでのノイズを減らし、コミュニケーションの場としての役割を強化するため、再接続通知を削除します。

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/526"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

