### PR TITLE
物件ガチャの発火条件を変更

### DIFF
--- a/room-gacha/index.ts
+++ b/room-gacha/index.ts
@@ -122,7 +122,7 @@ export default async ({rtmClient, webClient}: SlackInterface) => {
         if (message.channel !== process.env.CHANNEL_SANDBOX) return;
         if (!message.text) return;
         if (message.username === username) return;
-        if (message.text.startsWith('物件ガチャ')) {
+        if (message.text === '物件ガチャ' || message.text.startsWith('物件ガチャ ')) {
             const args: string[] = message.text.split(' ');
             const prefs = Object.keys(prefectures);
             const isValidPrefSpecified = args.length > 1 && prefs.includes(args[1]);


### PR DESCRIPTION
これまで「物件ガチャ」で始まるメッセージで発火していましたが、これだと「物件ガチャすき」のような言及メッセージでも発火してしまいます。現に時々発火してしまっていました。
というわけで、「物件ガチャ」単独でない限り、スペースが続かないと発火しないようにしました。

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/541"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

