### PR TITLE
占いで品詞を見るように改良

### DIFF
--- a/better-custom-response/custom-responses.ts
+++ b/better-custom-response/custom-responses.ts
@@ -214,16 +214,12 @@ const customResponses: CustomResponse[] = [
             const tokens = await tokenize(str);
             const choices = tokens.reduce<string[]>((prev, cur) => {
                 if (cur.pos === '助詞' && cur.surface_form === 'か') {
-                    return [
-                        ...prev,
-                        '',
-                    ];
+                    prev.push('');
+                    return prev;
                 }
-                return [
-                    ...prev.slice(0, -1),
-                    (prev[prev.length - 1] || '') + cur.surface_form,
-                ];
-            }, []).filter(s => s !== '');
+                prev[prev.length - 1] += cur.surface_form;
+                return prev;
+            }, ['']).filter(s => s !== '');
             const fukukitarify = (c: string) => stripIndent`\
                 :meishodoto_umamusume: 「救いは無いのですか～？」
                 :matikanefukukitaru_umamusume: 「むむっ…　:palms_up_together::crystal_ball:」

--- a/better-custom-response/custom-responses.ts
+++ b/better-custom-response/custom-responses.ts
@@ -212,14 +212,15 @@ const customResponses: CustomResponse[] = [
         outputFunction: async (input: string[]) => {
             const str = input[0].slice(0, -2);
             const tokens = await tokenize(str);
-            const choices = tokens.reduce<string[]>((prev, cur) => {
-                if (cur.pos === '助詞' && cur.surface_form === 'か') {
-                    prev.push('');
-                    return prev;
+            let choices = [''];
+            for (const token of tokens) {
+                if (token.pos === '助詞' && token.surface_form === 'か') {
+                    choices.push('');
+                } else {
+                    choices[choices.length - 1] += token.surface_form;
                 }
-                prev[prev.length - 1] += cur.surface_form;
-                return prev;
-            }, ['']).filter(s => s !== '');
+            }
+            choices = choices.filter(choice => choice !== '');
             const fukukitarify = (c: string) => stripIndent`\
                 :meishodoto_umamusume: 「救いは無いのですか～？」
                 :matikanefukukitaru_umamusume: 「むむっ…　:palms_up_together::crystal_ball:」


### PR DESCRIPTION
現状の占いは機械的に「か」を見ているため、「行くか行かないか占い」の選択肢は `['行く', '行', 'ない']` になってしまっています。助詞の「か」を見るようにして、これを改良しました。十分に高速です。

配列作る部分もう少し頭のいい書き方できねえかなあと思いながらこうなったのですが、いい書き方思いついた人はレビューで教えてくださいませ。

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/558"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

