### PR TITLE
lib/slack: emit message to event client in test

### DIFF
--- a/lib/slackMock.js
+++ b/lib/slackMock.js
@@ -56,13 +56,16 @@ module.exports = class SlackMock extends EventEmitter {
 			};
 
 			this.on('chat.postMessage', handleResponse);
-			this.rtmClient.emit('message', {
+
+			const data = {
 				channel: this.fakeChannel,
 				text: message,
 				user: this.fakeUser,
 				ts: this.fakeTimestamp,
 				type: "message",
-			});
+			};
+			this.rtmClient.emit('message', data);
+			this.eventClient.emit('message', data);
 		});
 	}
 };


### PR DESCRIPTION
part of #424 

getResponseのときに、eventClientのほうにも一緒にmessageをpublishする

https://github.com/tsg-ut/slackbot/pull/575 このへんでテストが落ちたため

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/577"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

