### PR TITLE
lib/slackutils: deprecate rtm

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ process.on('unhandledRejection', (error: Error) => {
 
 import os from 'os';
 import {rtmClient, webClient} from './lib/slack';
+import {initilizeEventClient} from './lib/slackUtils';
 import {createEventAdapter} from '@slack/events-api';
 import {createMessageAdapter} from '@slack/interactive-messages';
 import Fastify from 'fastify';
@@ -110,6 +111,7 @@ const eventClient = createEventAdapter(process.env.SIGNING_SECRET);
 eventClient.on('error', (error) => {
 	logger.error(error.stack);
 });
+initilizeEventClient(eventClient);
 
 const messageClient = createMessageAdapter(process.env.SIGNING_SECRET);
 


### PR DESCRIPTION
part of #424 

え、動く気しません　たすけて

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/632"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

f7201d8 はindent fixだけなので、 e47f671 でreviewするといいです

#### TODO
- [x] team_join
- [x] user_change
- [x] emoji_changed
- [x] message
- [x] reaction_added
- [x] reaction_removed