### PR TITLE
createTSGEventClient

### DIFF
--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -2,6 +2,7 @@ import {WebClient} from '@slack/web-api';
 import {RTMClient} from '@slack/rtm-api';
 import {createEventAdapter} from '@slack/events-api';
 import {createMessageAdapter} from '@slack/interactive-messages';
+import type {TSGEventClient} from './slackEventClient';
 import {Deferred} from './utils';
 import {Token} from '../oauth/tokens';
 import sql from 'sql-template-strings';
@@ -12,7 +13,7 @@ import path from 'path';
 export interface SlackInterface {
 	rtmClient: RTMClient;
 	webClient: WebClient;
-	eventClient: ReturnType<typeof createEventAdapter>;
+	eventClient: TSGEventClient;
 	messageClient: ReturnType<typeof createMessageAdapter>;
 };
 

--- a/lib/slackEventClient.ts
+++ b/lib/slackEventClient.ts
@@ -1,0 +1,24 @@
+import type EventEmitter from 'events';
+
+export interface TSGEventClient {
+	emit(event: string, ...args: any[]): boolean;
+	on(event: string, listener: (...args: any[]) => void): any;
+	onAllTeam(event: string, listener: (...args: any[]) => void): any;
+	// feel free to add any EventEmitter properties if you want to use!
+};
+
+export const createTSGEventClient = (team: string, eventClient: EventEmitter): TSGEventClient => {
+	return {
+		onAllTeam(event: string, listener: (...args: any[]) => void) {
+			return eventClient.on(event, listener);
+		},
+		on(event: string, listener: (...args: any[]) => void) {
+			return eventClient.on(event, (...args) => {
+				if (args[0]?.team_id === team) {
+					listener(...args);
+				}
+			});
+		},
+		...eventClient,
+	};
+};

--- a/tunnel/index.ts
+++ b/tunnel/index.ts
@@ -221,7 +221,7 @@ export const server = ({webClient: tsgSlack, eventClient}: SlackInterface) => {
 		};
 
 		for (const eventType of ['reaction_added', 'reaction_removed']) {
-			eventClient.on(eventType, (event: any) => {
+			eventClient.onAllTeam(eventType, (event: any) => {
 				const team =
 					event.team_id === process.env.TEAM_ID ? 'TSG'
 						: event.team_id === process.env.KMC_TEAM_ID ? 'KMC'


### PR DESCRIPTION
Resolve #638 

tsg-ut/slackbotはtsgのためのbotなので、eventClientくん、基本的にいままでのrtmclientを踏襲した、TSGのデータだけ来る仕様でいいと思っています。
全部データを欲しい人だけexplicitに `onAllTeam` で購読すればいいと思うんです。

### TEST
```test.js
const ee = new EventEmitter;
const te = createTSGEventClient('hoge', ee);
te.on('ev', (e) => console.log('1', e.msg));
te.onAllTeam('ev', (e) => console.log('2', e.msg));
ee.emit('ew', {team_id: 'hoge', msg: '1'});
ee.emit('ev', {team_id: 'hoge', msg: '2'});
ee.emit('ev', {team_id: 'fuga', msg: '3'});
```
```
1 2
2 2
2 3
```