### PR TITLE
atcoder: コンテスト名のⒶⒽが付かないようにする

### DIFF
--- a/atcoder/index.ts
+++ b/atcoder/index.ts
@@ -132,8 +132,7 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
 						convert: (time) => new Date(time).getTime(),
 					},
 					title: {
-						selector: 'td:nth-child(2)',
-						convert: (title) => title.replace('◉', '').trim(),
+						selector: 'td:nth-child(2) a',
 					},
 					id: {
 						selector: 'td:nth-child(2) a',


### PR DESCRIPTION
コンテスト名の取り出し方を変更し、囲み文字が含まれないよう変更しました。

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/648"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

