### PR TITLE
bcr をスレッド対応

### DIFF
--- a/better-custom-response/index.ts
+++ b/better-custom-response/index.ts
@@ -155,7 +155,7 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
 
     eventClient.on('message', async (message) => {
         if (!message.user || message.user.startsWith('B') || message.user === 'UEJTPN6R5' || message.user === 'USLACKBOT') return;
-        const {channel, text, ts: timestamp, user} = message;
+        const {channel, text, ts: timestamp, user, thread_broadcast} = message;
         if (!text) return;
         const context: Context = {user};
         const resp = await response(text, context, state.textResponses);
@@ -167,6 +167,8 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
                 text: resp.text,
                 username,
                 icon_emoji,
+                thread_ts: timestamp,
+                reply_broadcast: thread_broadcast,
             });
             for (const achievementID of resp.achievements) {
                 await unlock(message.user, achievementID);


### PR DESCRIPTION
現状の bcr は、スレッド内で発火した場合も、メインのチャンネルの方に流れてしまいます。文脈不明になる。

これを解決し、スレッド内でレスポンスを返すようにしました。また、発火の原因となる投稿が also sent to channel されている場合、レスポンスもそれに合わせます。

これらの挙動をオプションで指定できるようにしようかとも思いましたが、全部この仕様にしても問題ないのではないかと考え、そうしました。

動作確認はしてないけど多分これでええんちゃうかなと思うとります。(テキトー)

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/652"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

