### PR TITLE
ci: split coverage into npm run test:coverage command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Test
-        run: npm test
+        run: npm run test:coverage
         env:
           NODE_OPTIONS: --trace-warnings --trace-deprecation --trace-exit --trace-uncaught --unhandled-rejections=strict
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dev": "ts-node-dev --respawn --rs --ignore-watch \".json$\" index.ts",
     "lint": "sed \"s/\\/.\\+//g\" CODEOWNERS | grep \"^[a-z]\" | awk '{print $1}' | xargs -n 1 eslint --ext js,ts",
     "fix": "npm run lint -- --fix",
-    "test": "jest --verbose --coverage --detectOpenHandles --forceExit"
+    "test": "jest --verbose --detectOpenHandles --forceExit",
+    "test:coverage": "npm run test -- --coverage"
   },
   "engines": {
     "node": ">=16.10.0"


### PR DESCRIPTION
これは自分本位過ぎるPRかもしれないんですが、僕いつも、たとえばwelcomeだけtestしたいとき、ローカルでだけこのpackage.jsonのパッチ入れて
```
npm test -- --testPathPattern welcome
```
とかやってるんですよね。--coverage、なんかしらないけどだいぶ重い...やってられない...

--coverageオプションを抜くことによって、ローカルでのテスト実行時間の短縮ができ、テストの機運が全体で上がるため、テストカバレッジの上昇が図れると思います！！！！！！

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/668"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

