### PR TITLE
[fix] ミラーラビンのライブラリが偶数に対応していないので、弾くようにした

### DIFF
--- a/prime/index.js
+++ b/prime/index.js
@@ -106,6 +106,9 @@ const getFrequency = async (numberString) => {
 	}
 
 	if (numberString.length <= 200) {
+		if (parseInt(numberString[numberString.length - 1]) % 2 === 0) {
+			return false;
+		}
 		return millerRabin.test(new BN(numberString));
 	}
 


### PR DESCRIPTION
名前のとおりです