### PR TITLE
lib/SlackCache: deprecate rtm

### DIFF
--- a/amongyou/index.ts
+++ b/amongyou/index.ts
@@ -1,6 +1,6 @@
 import {constants, promises as fs} from 'fs';
 import path from 'path';
-import type {TSGEventClient} from '../lib/slackEventClient';
+import type {TeamEventClient} from '../lib/slackEventClient';
 import {ChatPostMessageArguments, WebClient} from '@slack/web-api';
 import {stripIndent} from 'common-tags';
 import type {FastifyPluginCallback} from 'fastify';
@@ -131,7 +131,7 @@ const getBlocks = () => [
 ];
 
 class Among {
-	eventClient: TSGEventClient;
+	eventClient: TeamEventClient;
 
 	slack: WebClient;
 
@@ -149,7 +149,7 @@ class Among {
 		slack,
 		slackInteractions,
 	}: {
-		eventClient: TSGEventClient,
+		eventClient: TeamEventClient,
 		slack: WebClient,
 		slackInteractions: any,
 	}) {

--- a/atequiz/index.ts
+++ b/atequiz/index.ts
@@ -1,5 +1,5 @@
 import { WebAPICallOptions, WebClient } from '@slack/web-api';
-import type { TSGEventClient } from '../lib/slackEventClient';
+import type { TeamEventClient } from '../lib/slackEventClient';
 import { SlackInterface } from '../lib/slack';
 import { ChatPostMessageArguments } from '@slack/web-api/dist/methods';
 import assert from 'assert';
@@ -51,7 +51,7 @@ export const typicalMessageTextsGenerator = {
  * To use other judge/watSecGen/ngReaction, please extend this class.
  */
 export class AteQuiz {
-  eventClient: TSGEventClient;
+  eventClient: TeamEventClient;
   slack: WebClient;
   problem: AteQuizProblem;
   ngReaction = 'no_good';

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -6,14 +6,14 @@ import sql from 'sql-template-strings';
 import * as sqlite from 'sqlite';
 import sqlite3 from 'sqlite3';
 import path from 'path';
-import {TSGEventClient} from './slackEventClient';
+import {TeamEventClient} from './slackEventClient';
 import {Deferred} from './utils';
 import {Token} from '../oauth/tokens';
 
 export interface SlackInterface {
 	rtmClient: RTMClient;
 	webClient: WebClient;
-	eventClient: TSGEventClient;
+	eventClient: TeamEventClient;
 	messageClient: ReturnType<typeof createMessageAdapter>;
 };
 
@@ -46,7 +46,7 @@ export const rtmClient = new RTMClient(process.env.SLACK_TOKEN);
 export const webClient = new WebClient(process.env.SLACK_TOKEN);
 export const eventClient = createEventAdapter(process.env.SIGNING_SECRET, {includeBody: true});
 export const messageClient = createMessageAdapter(process.env.SIGNING_SECRET);
-export const tsgEventClient = new TSGEventClient(
+export const tsgEventClient = new TeamEventClient(
 	eventClient,
 	process.env.TEAM_ID,
 );

--- a/lib/slackEventClient.ts
+++ b/lib/slackEventClient.ts
@@ -1,6 +1,6 @@
 import type {SlackEventAdapter} from '@slack/events-api';
 
-export class TSGEventClient {
+export class TeamEventClient {
 	private readonly eventAdapter: SlackEventAdapter;
 	private readonly team: string;
 
@@ -14,7 +14,7 @@ export class TSGEventClient {
 	onAllTeam(event: string, listener: (...args: any[]) => void): any {
 		return this.eventAdapter.on(event, listener);
 	}
-	// listen on events against TSG team.
+	// listen on events against the team.
 	on(event: string, listener: (...args: any[]) => void): any {
 		return this.eventAdapter.on(event, (...args: any[]) => {
 			// https://slack.dev/node-slack-sdk/events-api#receive-additional-event-data

--- a/lib/slackUtils.ts
+++ b/lib/slackUtils.ts
@@ -1,8 +1,7 @@
 import type {MrkdwnElement, PlainTextElement} from '@slack/web-api';
 import type {Member} from '@slack/web-api/dist/response/UsersListResponse';
 import {WebClient} from '@slack/web-api';
-import type {RTMClient} from '@slack/rtm-api';
-import {getTokens, getRtmClient} from './slack';
+import {eventClient, getTokens} from './slack';
 import {Deferred} from './utils';
 import SlackCache from './slackCache';
 
@@ -13,10 +12,9 @@ const initializedSlackCachesDeferred = new Deferred<void>();
 (async function initializedSlackCaches() {
 	const tokens = await getTokens();
 	for (const token of tokens) {
-		const rtmClient: RTMClient = await getRtmClient(token.team_id);
 		slackCaches.set(token.team_id, new SlackCache({
 			token,
-			rtmClient,
+			eventClient,
 			webClient: new WebClient(),
 			enableReactions: token.team_id === process.env.TEAM_ID,
 		}));

--- a/oogiri/index.ts
+++ b/oogiri/index.ts
@@ -4,7 +4,7 @@
 // eslint-disable-next-line no-unused-vars
 import {constants, promises as fs} from 'fs';
 import path from 'path';
-import type {TSGEventClient} from '../lib/slackEventClient';
+import type {TeamEventClient} from '../lib/slackEventClient';
 import type {KnownBlock, WebClient} from '@slack/web-api';
 import {Mutex} from 'async-mutex';
 import {stripIndent} from 'common-tags';
@@ -47,7 +47,7 @@ interface State {
 const mutex = new Mutex();
 
 class Oogiri {
-	eventClient: TSGEventClient;
+	eventClient: TeamEventClient;
 
 	slack: WebClient;
 
@@ -64,7 +64,7 @@ class Oogiri {
 		slack,
 		slackInteractions,
 	}: {
-		eventClient: TSGEventClient,
+		eventClient: TeamEventClient,
 		slack: WebClient,
 		slackInteractions: any,
 	}) {


### PR DESCRIPTION
part of #424 

#642 の続きです rtm clientをevent client with team filterに置換します

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/676"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

