### PR TITLE
ricochet-robots: fix path reconstruction

### DIFF
--- a/ricochet-robots/src/main.rs
+++ b/ricochet-robots/src/main.rs
@@ -373,13 +373,15 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 					break;
 				}
 				for (ts, m) in st.enumerate_states(&bo) {
-					//moving prev.contains & prev.insert to here decreased speed.
-					//I don't understand why this happened. :thinking_face:
-					if !prev.contains_key(&ts) {
+					// kcz-san and satos-san say that performing `push_back` here
+					// decreases speed, but this is necessary for path reconstruction.
+					// However, using `entry` instead of `contains_key` and `insert`
+					// increases speed a bit. (ura)
+					prev.entry(ts).or_insert_with(|| {
 						que.push_back(Some(ts));
 						let p = st.robots[m.c];
-						prev.insert(ts, Some(Prev::serailize(&m, &p)));
-					}
+						Some(Prev::serailize(&m, &p))
+					});
 				}
 			}
 			None => {

--- a/ricochet-robots/src/main.rs
+++ b/ricochet-robots/src/main.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::env;
 use std::hash::{Hash, Hasher};
@@ -202,19 +201,13 @@ pub struct Move {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 struct State {
-	// bo: &'a Board,
 	robots: [Pos; ROBOTS_COUNT],
-	//log: SinglyLinkedList
-	// log: usize,
 }
 
 impl State {
 	pub fn init_state(bo: &Board) -> State {
-		//State{bo: &bo,robots: bo.robots.clone(), log: SinglyLinkedList::nil()}
 		State {
-			// bo: &bo,
 			robots: bo.robots.clone(),
-			// log: 1,
 		}
 	}
 
@@ -277,11 +270,8 @@ impl State {
 			x: p.x + dir.x * mind,
 		};
 
-		// let tolog = self.log << 4 | robot_index << 2 | robot_dir; //self.log.cons(Move{c: robot_index,d: robot_dir});
 		let mut res = State {
-			// bo: self.bo,
 			robots: self.robots.clone(),
-			// log: tolog,
 		};
 		res.robots[robot_index] = p;
 		Some(res)
@@ -292,7 +282,6 @@ impl State {
 		for i in 0..self.robots.len() {
 			for j in 0..4 {
 				if let Some(ts) = self.move_to(board, i, j) {
-					// res.push(ts);
 					res.push((ts, Move { c: i, d: j }));
 				}
 			}
@@ -300,13 +289,6 @@ impl State {
 		return res;
 	}
 }
-
-// impl PartialEq for State {
-// 	fn eq(&self, ts: &State) -> bool {
-// 		return self.robots == ts.robots;
-// 	}
-// }
-// impl Eq for State {}
 
 impl Hash for State {
 	fn hash<H: Hasher>(&self, state: &mut H) {
@@ -349,12 +331,8 @@ impl Prev {
 
 pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 	let init = State::init_state(&bo);
-	//let mut res = init.log.head.clone();
-	// let mut res = init.log;
 	let mut goal = (0, init.robots[0]);
 
-	// let mut gone: HashSet<State> = HashSet::new();
-	//let mut gone: HashSet<Vec<Pos>> = HashSet::new();
 	let mut prev: HashMap<State, Option<Prev>> = HashMap::new();
 
 	let mut que = VecDeque::new();
@@ -368,14 +346,12 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 
 	let mut last_state = init;
 
-	// gone.insert(init);
 	prev.insert(init, None);
 
 	let mut dnum = 1;
 	while let Some(st) = que.pop_front() {
 		match st {
 			Some(st) => {
-				// if !gone.contains(&st) {
 				last_state = st;
 				dnum += 1;
 				//println!("{:?}",st.robots);
@@ -386,8 +362,6 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 						//println!("{} {} {} : {} ",p.y,p.x,i,depth);
 						found[p.y as usize][p.x as usize][i] = true;
 						found_count += 1;
-						//res = st.log.head.clone();
-						// res = st.log;
 						goal = (i, p);
 						if depth >= target || found_count >= max_pattern_num {
 							ok = true;
@@ -399,7 +373,7 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 					break;
 				}
 				for (ts, m) in st.enumerate_states(&bo) {
-					//moving gone.contains & gone.insert to here decreased speed.
+					//moving prev.contains & prev.insert to here decreased speed.
 					//I don't understand why this happened. :thinking_face:
 					if !prev.contains_key(&ts) {
 						que.push_back(Some(ts));
@@ -407,8 +381,6 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 						prev.insert(ts, Some(Prev::serailize(&m, &p)));
 					}
 				}
-				// gone.insert(st);
-				// }
 			}
 			None => {
 				depth += 1;
@@ -421,17 +393,6 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 			}
 		}
 	}
-
-	// {
-	// 	// Faster!!. Haee! 0.69s to 0.53s
-	// 	let mut l = vec![];
-	// 	while res > 1 {
-	// 		let c = (res & 12) >> 2;
-	// 		let d = res & 3;
-	// 		l.push(Move { c: c, d: d });
-	// 		res >>= 4;
-	// 	}
-	// }
 
 	let mut l = vec![];
 	let mut s = last_state;
@@ -449,8 +410,6 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 	}
 
 	return (goal, l);
-	//let l = SinglyLinkedList{head: res};
-	//return (goal,l.to_vec());
 }
 
 fn main() {

--- a/ricochet-robots/src/main.rs
+++ b/ricochet-robots/src/main.rs
@@ -304,29 +304,32 @@ impl Hash for State {
 }
 
 /**
- * its internal representation is like below:
+ * Its internal representation is like below:
  *
- *                  0b_0000_00000000_00000000
+ *                  0b_00000000_00000000
  *     robot_index     ^^
  *       robot_dir       ^^
- *          prev_y          ^^^^^^^^
- *          prev_x                   ^^^^^^^^
+ *          prev_y         ^^^^ ^^
+ *          prev_x                ^^^^^^
  *
- * making the data compact increases speed a little. (ura)
+ * Assume that
+ *   - the number of robots < 4 and
+ *   - the width and height of the board < 64.
+ * Making the data compact increases speed a little. (ura)
  */
-struct Prev(u64);
+struct Prev(u16);
 
 impl Prev {
 	fn serialize(m: &Move, p: &Pos) -> Self {
-		let prev = ((m.c as u64) << 18) | ((m.d as u64) << 16) | ((p.y as u64) << 8) | (p.x as u64);
+		let prev = ((m.c as u16) << 14) | ((m.d as u16) << 12) | ((p.y as u16) << 6) | (p.x as u16);
 		Prev(prev)
 	}
 
 	fn deserialize(&self) -> (Move, Pos) {
-		let robot_index = (self.0 >> 18) as usize;
-		let robot_dir = ((self.0 >> 16) & 0b11) as usize;
-		let prev_y = ((self.0 >> 8) & 0xff) as i8;
-		let prev_x = (self.0 & 0xff) as i8;
+		let robot_index = (self.0 >> 14) as usize;
+		let robot_dir = ((self.0 >> 12) & 0b11) as usize;
+		let prev_y = ((self.0 >> 6) & 0b111111) as i8;
+		let prev_x = (self.0 & 0b111111) as i8;
 		(
 			Move {
 				c: robot_index,

--- a/ricochet-robots/src/main.rs
+++ b/ricochet-robots/src/main.rs
@@ -349,9 +349,9 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 	// let mut res = init.log;
 	let mut goal = (0, init.robots[0]);
 
-	let mut gone: HashSet<State> = HashSet::new();
+	// let mut gone: HashSet<State> = HashSet::new();
 	//let mut gone: HashSet<Vec<Pos>> = HashSet::new();
-	let mut prev: HashMap<State, Prev> = HashMap::new();
+	let mut prev: HashMap<State, Option<Prev>> = HashMap::new();
 
 	let mut que = VecDeque::new();
 	let mut depth = 0;
@@ -364,7 +364,8 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 
 	let mut last_state = init;
 
-	gone.insert(init);
+	// gone.insert(init);
+	prev.insert(init, None);
 
 	let mut dnum = 1;
 	while let Some(st) = que.pop_front() {
@@ -396,11 +397,10 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 				for (ts, m) in st.enumerate_states(&bo) {
 					//moving gone.contains & gone.insert to here decreased speed.
 					//I don't understand why this happened. :thinking_face:
-					if !gone.contains(&ts) {
-						gone.insert(ts);
+					if !prev.contains_key(&ts) {
 						que.push_back(Some(ts));
 						let p = st.robots[m.c];
-						prev.insert(ts, Prev::serailize(&m, &p));
+						prev.insert(ts, Some(Prev::serailize(&m, &p)));
 					}
 				}
 				// gone.insert(st);
@@ -432,7 +432,7 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 	let mut l = vec![];
 	let mut s = last_state;
 	loop {
-		match prev.get(&s) {
+		match &prev[&s] {
 			Some(prev) => {
 				let (m, p) = prev.deserialize();
 				l.push(m);

--- a/ricochet-robots/src/main.rs
+++ b/ricochet-robots/src/main.rs
@@ -199,7 +199,7 @@ pub struct Move {
 	d: usize,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 struct State {
 	robots: [Pos; ROBOTS_COUNT],
 }
@@ -342,9 +342,11 @@ impl Prev {
 
 pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 	let init = State::init_state(&bo);
+	let mut last_state = init.clone();
 	let mut goal = (0, init.robots[0]);
 
 	let mut prev: HashMap<State, Option<Prev>> = HashMap::new();
+	prev.insert(init.clone(), None);
 
 	let mut que = VecDeque::new();
 	let mut depth = 0;
@@ -355,15 +357,11 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 	let mut found_count = 0;
 	let max_pattern_num = bo.h * bo.w * bo.robots.len();
 
-	let mut last_state = init;
-
-	prev.insert(init, None);
-
 	let mut dnum = 1;
 	while let Some(st) = que.pop_front() {
 		match st {
 			Some(st) => {
-				last_state = st;
+				last_state = st.clone();
 				dnum += 1;
 				//println!("{:?}",st.robots);
 				let mut ok = false;
@@ -388,7 +386,7 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 					// decreases speed, but this is necessary for path reconstruction.
 					// However, using `entry` instead of `contains_key` and `insert`
 					// increases speed a bit. (ura)
-					prev.entry(ts).or_insert_with(|| {
+					prev.entry(ts.clone()).or_insert_with(|| {
 						que.push_back(Some(ts));
 						let p = st.robots[m.c];
 						Some(Prev::serialize(&m, &p))

--- a/ricochet-robots/src/main.rs
+++ b/ricochet-robots/src/main.rs
@@ -303,6 +303,17 @@ impl Hash for State {
 	}
 }
 
+/**
+ * its internal representation is like below:
+ *
+ * 	                0b_0000_00000000_00000000
+ *     robot_index     ^^
+ *       robot_dir       ^^
+ *          prev_y          ^^^^^^^^
+ *          prev_x                   ^^^^^^^^
+ *
+ * making the data compact increases speed a little. (ura)
+ */
 struct Prev(u64);
 
 impl Prev {
@@ -396,19 +407,13 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 		}
 	}
 
+	// path reconstruction
 	let mut l = vec![];
 	let mut s = last_state;
-	loop {
-		match &prev[&s] {
-			Some(prev) => {
-				let (m, p) = prev.deserialize();
-				l.push(m);
-				s.robots[m.c] = p;
-			}
-			None => {
-				break;
-			}
-		}
+	while let Some(prev) = &prev[&s] {
+		let (m, p) = prev.deserialize();
+		l.push(m);
+		s.robots[m.c] = p;
 	}
 
 	return (goal, l);

--- a/ricochet-robots/src/main.rs
+++ b/ricochet-robots/src/main.rs
@@ -306,7 +306,7 @@ impl Hash for State {
 /**
  * its internal representation is like below:
  *
- * 	                0b_0000_00000000_00000000
+ *                  0b_0000_00000000_00000000
  *     robot_index     ^^
  *       robot_dir       ^^
  *          prev_y          ^^^^^^^^

--- a/ricochet-robots/src/main.rs
+++ b/ricochet-robots/src/main.rs
@@ -21,7 +21,7 @@ use atoi::atoi;
 extern crate itertools;
 use itertools::Itertools;
 
-#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct Pos {
 	y: i8,
 	x: i8,

--- a/ricochet-robots/src/main.rs
+++ b/ricochet-robots/src/main.rs
@@ -317,7 +317,7 @@ impl Hash for State {
 struct Prev(u64);
 
 impl Prev {
-	fn serailize(m: &Move, p: &Pos) -> Self {
+	fn serialize(m: &Move, p: &Pos) -> Self {
 		let prev = ((m.c as u64) << 18) | ((m.d as u64) << 16) | ((p.y as u64) << 8) | (p.x as u64);
 		Prev(prev)
 	}
@@ -391,7 +391,7 @@ pub fn bfs<'a, 'b>(target: u8, bo: &'a Board) -> ((usize, Pos), Vec<Move>) {
 					prev.entry(ts).or_insert_with(|| {
 						que.push_back(Some(ts));
 						let p = st.robots[m.c];
-						Some(Prev::serailize(&m, &p))
+						Some(Prev::serialize(&m, &p))
 					});
 				}
 			}

--- a/ricochet-robots/src/main.rs
+++ b/ricochet-robots/src/main.rs
@@ -200,7 +200,7 @@ pub struct Move {
 	d: usize,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 struct State {
 	// bo: &'a Board,
 	robots: [Pos; ROBOTS_COUNT],
@@ -308,14 +308,18 @@ impl State {
 // }
 // impl Eq for State {}
 
-// impl Hash for State {
-// 	fn hash<H: Hasher>(&self, state: &mut H) {
-// 		//Surprisingly, this makes program very slowly!
-// 		//:thinking_face:
-// 		// self.robots[0].y.hash(state);
-// 		self.robots.hash(state);
-// 	}
-// }
+impl Hash for State {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		//Surprisingly, this makes program very fast!
+		//:waiwai:
+		let mut bits: u64 = 0;
+		for i in 0..ROBOTS_COUNT {
+			let p = self.robots[i];
+			bits |= (((p.y as u64) << 8) | (p.x as u64)) << (i * 16);
+		}
+		bits.hash(state);
+	}
+}
 
 struct Prev(u64);
 


### PR DESCRIPTION
## 概要

動かし方の履歴が、1 手あたり 4 ビットとして `state.log: usize` に記録していく方式だったため、16 手以上のときにバグっていた。

ということで、`Map<状態, 前回の動きと状態>` みたいなのを持っておいて、経路復元する方式で再実装する。

## ベンチマーク

処理速度がだいぶチューニングされているので、一応そちらも気にしつつやってみる。

まず benchmarker.rs を以下の設定 (ハイパーロボット用) にする。それに応じて bench_correctness_check.txt も変える。
```rust
	let board_h = 7;
	let board_w = 9;
	let wall_num = 15;
	let num_of_problem = 10;
```

リリースモードでベンチマークを走らせる。
```sh
cd ricochet-robots
cargo run --release --bin ricochet_robot_benchmarker
```

3 回ほどやってみて、その中央値を記録していくことにする。

## 結果

変更する前は手元の PC で 3.665s だった。

### https://github.com/tsg-ut/slackbot/pull/684/commits/27de8a87c835cd580314bf7fac304b596f486c01

- とりあえず経路復元: 6.838s
- `res` をなくした: 6.474s
- `log` をなくした: 5.949s

### https://github.com/tsg-ut/slackbot/pull/684/commits/45fc8b161b3f9a00932c78f464b7fb329b05886a
- `board` をなくした: 5.604s
- `PartialEq`, `Eq`, `Hash` をデフォルト実装にした: 5.480s

### https://github.com/tsg-ut/slackbot/pull/684/commits/a586890dc7a628162eb8a2b06df2ed7943ec8cc4
- `Optional<Prev>` にした: 5.580s
- `gone` をなくした: 4.793s

### ボツ
- ~~`Prev` の `serialize`/`deserialize` をやめて単純な `struct` にした: 4.570s~~
- ~~`u8` → `i8`, `usize`: 5.080s~~

### https://github.com/tsg-ut/slackbot/pull/684/commits/f6864f43b0e0dfe8513674e38452a138355bb793
- `Hash` を自前実装した: 3.554s (!!!)

### https://github.com/tsg-ut/slackbot/pull/684/commits/e0ee6990e4fc4b16e64d7c9c62a719ce202e094d
- `entry` を使う: 3.407s

## 結論

経路復元によって少し遅くなったが、ハッシュ化をうまくやることでかなり高速になり、結果として最初よりも速くなった。


<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/684"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

