### PR TITLE
lib: SlackCache.getReactionsでリアクションしたユーザーの一覧を保持し返すよう修正

### DIFF
--- a/achievements/index_production.ts
+++ b/achievements/index_production.ts
@@ -102,7 +102,7 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 				return;
 			}
 			const reactions = await getReactions(event.item.channel, event.item.ts);
-			const targetReaction = reactions[event.reaction] || 0;
+			const targetReaction = reactions[event.reaction]?.length || 0;
 			const messageURL = event.item.type === 'message'
 				? `<https://tsg-ut.slack.com/archives/${event.item.channel}/p${event.item.ts.replace('.', '')}|[メッセージ]>`
 				: '';

--- a/lib/slackCache.ts
+++ b/lib/slackCache.ts
@@ -193,7 +193,7 @@ export default class SlackCache {
 						reactions[reaction].push(user);
 					}
 				} else {
-					let index = reactions[reaction].indexOf(user);
+					const index = reactions[reaction].indexOf(user);
 					if (index !== -1) {
 						reactions[reaction].splice(index, 1);
 					}
@@ -222,7 +222,7 @@ export default class SlackCache {
 						reactions[reaction].push(user);
 					}
 				} else {
-					let index = reactions[reaction].indexOf(user);
+					const index = reactions[reaction].indexOf(user);
 					if (index !== -1) {
 						reactions[reaction].splice(index, 1);
 					}

--- a/topic/index.ts
+++ b/topic/index.ts
@@ -73,7 +73,8 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
 		}
 
 		const reactions = await getReactions(event.item.channel, event.item.ts);
-		if (reactions.koresuki < 5) {
+		const koresukiCount = reactions.koresuki?.length || 0;
+		if (koresukiCount < 5) {
 			return;
 		}
 


### PR DESCRIPTION
### モチベーション

メッセージにリアクションしたユーザーのIDを利用した実績を実装したい (:koresuki:がたくさんついたメッセージに最初にリアクションしたらえらい、など)

### 変更点

SlackCacheのreactionsCacheを「リアクション名からリアクション数へのハッシュ」から「リアクション名からリアクションしたユーザーの配列へのハッシュ」に変更した。

リアクションしたユーザーIDを保持することで、同じユーザーのリアクションが複数届いてリアクション数のカウンタがおかしくなるなどの挙動がなくなり、動作の安定性が増すのではないかと思われる。

### 懸念点

* メモリパフォーマンスがちょっと悪くなりそう
* 配列への操作がmutableなのがちょっとキモい
* addとremoveが同じ関数なのがちょっとキモい

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/685"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

