### PR TITLE
[fix] octas中のデッドロックの修正

### DIFF
--- a/octas/index.ts
+++ b/octas/index.ts
@@ -224,7 +224,7 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
     const ProcessHand = async (message: any) => {
         if (state.board.ended) {
             // いつのまにか終っている　強制終了
-            await processQueue.add(Halt);
+            processQueue.add(Halt);
             return;
         }
         const cmd2dir = new Map([
@@ -358,7 +358,7 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
                     }
                 }
             }
-            await processQueue.add(Halt);
+            processQueue.add(Halt);
             return;
         }
     };


### PR DESCRIPTION
- バグの内容: octasの対戦終了後の`Halt`が呼び出されておらず、2戦目以降ができない状況になっていた
- 原因: p-queueへaddされた関数の中で更に`que.add`をawaitすると、p-queueがデッドロックに陥る
- 修正内容: いくつかのawaitを消した
