### PR TITLE
きらファン当てクイズ easy

### DIFF
--- a/kirafan/quiz.ts
+++ b/kirafan/quiz.ts
@@ -435,5 +435,24 @@ export default (slackClients: SlackInterface): void => {
         }
       }
     }
+
+    if (message.text.match(/^きらファン当てクイズ (easy|[☆★]3)$/)) {
+      const randomKirafanCard = sample((await getKirafanCards()).filter(card => card.rare === 2));
+      const problem = await generateProblem(randomKirafanCard);
+      const quiz = new KirafanAteQuiz(slackClients, problem, postOption);
+      const result = await quiz.start();
+      if (result.state === 'solved') {
+        await increment(result.correctAnswerer, 'kirafan-easy-answer');
+        if (result.hintIndex === 0) {
+          await increment(result.correctAnswerer, 'kirafan-easy-answer-first-hint');
+        }
+        if (result.hintIndex <= 1) {
+          await increment(result.correctAnswerer, 'kirafan-easy-answer-second-hint');
+        }
+        if (result.hintIndex <= 2) {
+          await increment(result.correctAnswerer, 'kirafan-easy-answer-third-hint');
+        }
+      }
+    }
   });
 };

--- a/kirafan/quiz.ts
+++ b/kirafan/quiz.ts
@@ -399,6 +399,11 @@ const postOption = {
   username: 'クレア',
 };
 
+const postOptionEasy = {
+  icon_emoji: ':claire_kirarafantasia:',
+  username: 'クレア（やさしい）',
+};
+
 export default (slackClients: SlackInterface): void => {
   const { eventClient } = slackClients;
 
@@ -439,7 +444,7 @@ export default (slackClients: SlackInterface): void => {
     if (message.text.match(/^きらファン当てクイズ (easy|[☆★]3)$/)) {
       const randomKirafanCard = sample((await getKirafanCards()).filter(card => card.rare === 2));
       const problem = await generateProblem(randomKirafanCard);
-      const quiz = new KirafanAteQuiz(slackClients, problem, postOption);
+      const quiz = new KirafanAteQuiz(slackClients, problem, postOptionEasy);
       const result = await quiz.start();
       if (result.state === 'solved') {
         await increment(result.correctAnswerer, 'kirafan-easy-answer');


### PR DESCRIPTION
出題範囲を有名作品や原作衣装に限ってほしいというご要望を受け、1235枚あった出題範囲を89枚の☆3キャラクターに制限したきらファン当てクイズ easy を実装しました。
☆3キャラクターのイラストにはきららファンタジアに参戦している37作品のうち初期に実装された11作品(ひだまりスケッチ、ゆゆ式、がっこうぐらし！、Aチャンネル、きんいろモザイク、NEW GAME!、ステラのまほう、うらら迷路帖、キルミーベイベー、桜Trick、ブレンド・S、スロウスタート、けいおん！)の、原作に登場したイラストが用いられています。

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/703"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

