### PR TITLE
アニソン当てクイズが動かない問題の修正

### DIFF
--- a/anime/anison.js
+++ b/anime/anison.js
@@ -69,10 +69,10 @@ const getSongInfos = async (title) => {
 			continue;
 		}
 		const songInfo = await getSongInfo(song.link, '');
-		const movieInfos = await getMovieInfo(songInfo.utaNetUrl.replace('song', 'movie'));
+		const movieInfo = await getMovieInfo(songInfo.utaNetUrl.replace('song', 'movie'));
 		songInfo.tokens = await tokenize(songInfo.paragraphs.join('\n'));
 		songInfo.type = song.type;
-		songInfo.movie = `https://youtu.be/${movieInfos[0].id}`;
+		songInfo.movie = `https://youtu.be/${movieInfo.id}`;
 		songInfo.animeTitle = title;
 
 		songInfo.forbiddenWords = uniq([

--- a/lyrics/index.ts
+++ b/lyrics/index.ts
@@ -22,7 +22,6 @@ interface SongInfo {
 interface MovieInfo {
     embedLink: string,
     id: string,
-    title: string,
 }
 
 interface iTunesInfo {
@@ -97,31 +96,21 @@ export const getSongInfo = async (songInfoUrl: string, keyword: string): Promise
     };
 };
 
-export const getMovieInfo = async (movieInfoUrl: string): Promise<MovieInfo[]> => {
+export const getMovieInfo = async (movieInfoUrl: string): Promise<MovieInfo> => {
     interface fetchedSongData {
-        movies: {embedLink: string, title: string}[];
+        embedLink: string;
     }
-    const {movies} = (await scrapeIt<fetchedSongData>(movieInfoUrl, {
-        movies: {
-            listItem: '#youtube_list .movie_l',
-            data: {
-                embedLink: {
-                    selector: 'a',
-                    attr: 'href',
-                },
-                title: {
-                    selector: 'a',
-                    attr: 'title',
-                },
-            },
+    const movies = (await scrapeIt<fetchedSongData>(movieInfoUrl, {
+        embedLink: {
+            selector: '.col-12.p-0 > iframe',
+            attr: 'src',
         },
     })).data;
 
-    return movies.map(({embedLink, title}) => ({
-        embedLink,
-        title,
-        id: new URL(embedLink).pathname.split('/')[2],
-    }));
+    return {
+        embedLink: movies.embedLink, 
+        id: new URL(movies.embedLink).pathname.split('/')[2],
+    };
 };
 
 const search = async (keyword: string): Promise<SongInfo | null> => {


### PR DESCRIPTION
- バグの内容
anime/anison が内部で使用している lyrics の getMovieInfo がうまく作動していない

- 原因
アニソン当てクイズ正解時に表示されるmovieのURLをlyricsのgetMovieInfo関数により取得しているが、Uta-Netの仕様変更によりhtmlの形式が変わったためうまくスクレイピングできていなかった

- 修正内容
1. スクレイピングする箇所を変更。 これに伴い、今まではgetMovieInfoは動画タイトルの情報や関連動画の情報も得ていたが、目的の動画のURLのみを返す関数になった。
2. getMovieInfoの戻り値を配列でなくしたため、anime/anison.jsにも若干の変更を加えた。

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/709"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

