### PR TITLE
[add] postMessage に対して {ts} を返すようにした

### DIFF
--- a/lib/slackMock.js
+++ b/lib/slackMock.js
@@ -46,6 +46,9 @@ module.exports = class SlackMock extends EventEmitter {
 				{id: 'CGENERAL', is_general: true},
 			]});
 		}
+		if (stack.join('.') ===  "chat.postMessage") {
+			return Promise.resolve({ok: true, ts: this.fakeTimestamp});
+		}
 		// TODO: make returned value customizable
 		return Promise.resolve([]);
 	}


### PR DESCRIPTION
slackMock.js の handleWebcall で、chat.postMessage は無視されてたんですが、（なぜか）AteQuiz では ts: string が帰ってこないと assert で落ちるようになってるので、そっちを消すよりはということで簡易的に ok と ts だけ返すようにしました。

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/711"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

