### PR TITLE
rm as_user in postMessage

### DIFF
--- a/pocky/index.js
+++ b/pocky/index.js
@@ -150,7 +150,6 @@ module.exports = async (clients) => {
 		return slack.chat.postMessage({
 			channel,
 			text: message,
-			as_user: false,
 			username: "pocky",
 			icon_emoji: ":google:",
 			thread_ts: threadPosted ? threadPosted : null,

--- a/tahoiya/index.js
+++ b/tahoiya/index.js
@@ -780,7 +780,6 @@ module.exports = async ({eventClient, webClient: slack}) => {
 		axios.post('https://slack.com/api/chat.postMessage', {
 			channel: process.env.CHANNEL_SANDBOX,
 			text: '@tahoist',
-			as_user: true,
 		}, {
 			headers: {
 				Authorization: `Bearer ${process.env.HAKATASHI_TOKEN}`,


### PR DESCRIPTION
Resolve #731 

* https://api.slack.com/methods/chat.postMessage
  > Set to true to post the message as the authed user, instead of as a bot. Defaults to false. Cannot be used by [new Slack apps](https://api.slack.com/authentication/basics). See [authorship](https://api.slack.com/methods/chat.postMessage#authorship) below.
* https://api.slack.com/authentication/quickstart#public
* ```
  {
  "bot": "index",
  "error": {
    "code": "slack_webapi_platform_error",
    "data": {
      "deprecated_argument": "as_user",
      "error": "invalid_arguments",
      "ok": false,
      "response_metadata": {
        "acceptedScopes": [
          "chat:write:bot"
        ],
        "scopes": [
   ...
        ]
      }
    }
  },
  "level": "error",
  "message": "unhandledRejection at: [object Promise] reason: An API error occurred: invalid_arguments",
  "promise": {},
  }

<a href="https://gitpod.io/#https://github.com/tsg-ut/slackbot/pull/733"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

