### PR TITLE
golfbot: Reduce database writes by introducing state checks

### DIFF
--- a/golfbot/index.ts
+++ b/golfbot/index.ts
@@ -826,7 +826,7 @@ export const server = ({eventClient, webClient: slack, messageClient: slackInter
 
 					// 終了したコンテストを削除
 					// stateへの書き込みを抑制するため、終了したコンテストが存在する場合のみ実行する
-					if (state.contests.some(contest => !(contest.endAt <= newTime))) {
+					if (state.contests.some(contest => contest.endAt <= newTime)) {
 						state.contests = state.contests.filter(contest => !(contest.endAt <= newTime));
 					}
 				});

--- a/golfbot/index.ts
+++ b/golfbot/index.ts
@@ -825,7 +825,10 @@ export const server = ({eventClient, webClient: slack, messageClient: slackInter
 					}
 
 					// 終了したコンテストを削除
-					state.contests = state.contests.filter(contest => !(contest.endAt <= newTime));
+					// stateへの書き込みを抑制するため、終了したコンテストが存在する場合のみ実行する
+					if (state.contests.some(contest => !(contest.endAt <= newTime))) {
+						state.contests = state.contests.filter(contest => !(contest.endAt <= newTime));
+					}
 				});
 			}, 30 * 1000);
 		}


### PR DESCRIPTION
Ref: #771

Firestoreに対する書き込みの統計を取ったところ、特にgolfbotの使用量が多い模様。

```
Firestore usage at Tue Dec 06 2022 22:00:00 GMT+0900 (Japan Standard Time): Map(12) {
 'state_golfbot_get' => 112,
 'state_golfbot_update' => 112,
 'achievements_U017Z5N3947_get' => 1,
 'achievements_U017Z5N3947_update' => 1,
 'achievements_UA47NQ9GV_get' => 2,
 'achievements_UA47NQ9GV_update' => 2,
 'state_atcoder_get' => 2,
 'state_atcoder_update' => 2,
 'achievements_U02EHTGAH9P_get' => 2,
 'achievements_U02EHTGAH9P_update' => 2,
 'achievements_U010FS4BPKR_get' => 4,
 'achievements_U010FS4BPKR_update' => 4
}
```

filter関数による代入は常にstateに対する書き込みを実施するため、filterされるものが存在する場合のみ実行するように修正しました