### PR TITLE
Discord入退室通知のバグを修正

### DIFF
--- a/discord/index.ts
+++ b/discord/index.ts
@@ -186,7 +186,7 @@ export default async ({webClient: slack, eventClient}: SlackInterface) => {
 				const roomName = oldState.channel.name;
 				const roomId = oldState.channel.id;
 				const count = oldState.channel.members.size;
-				const actionName = 'leave';
+				const actionName = `leave-${roomId}`;
 				const update = roomNotifyCache.lastUnixTime + notifyCacheLimit > eventTime && roomNotifyCache.action === actionName;
 
 				if (update) {
@@ -215,7 +215,7 @@ export default async ({webClient: slack, eventClient}: SlackInterface) => {
 				const roomName = newState.channel.name;
 				const roomId = newState.channel.id;
 				const count = newState.channel.members.size;
-				const actionName = 'join';
+				const actionName = `join-${roomId}`;
 				const update = roomNotifyCache.lastUnixTime + notifyCacheLimit > eventTime && roomNotifyCache.action === actionName;
 
 				if (update) {

--- a/mahjong/index.js
+++ b/mahjong/index.js
@@ -496,6 +496,16 @@ module.exports = (clients) => {
 				return;
 			}
 
+			if (text === '手牌表示') {
+				if (state.phase !== 'gaming') {
+					perdon();
+					return;
+				}
+
+				postMessage(state.手牌.join(''));
+				return;
+			}
+
 			if (text.startsWith('打') || text.startsWith('d') || text === 'ツモ切り') {
 				const instruction = normalize打牌Command(text);
 

--- a/mahjong/index.js
+++ b/mahjong/index.js
@@ -72,6 +72,14 @@ const 牌Names = [
 	'赤五萬', '赤五索', '赤五筒',
 ];
 
+const 採譜表示s = [
+	'東', '南', '西', '北', '中', '發', '白',
+	...(漢数字s.map((漢数字) => `${漢数字s.indexOf(漢数字) + 1}m`)),
+	...(漢数字s.map((漢数字) => `${漢数字s.indexOf(漢数字) + 1}s`)),
+	...(漢数字s.map((漢数字) => `${漢数字s.indexOf(漢数字) + 1}p`)),
+	'r5m', 'r5s', 'r5p',
+];
+
 const nameTo牌 = (name) => {
 	const normalized = name.startsWith('赤') ? name.slice(1) : name;
 	const 牌 = String.fromCodePoint(0x1F000 + 牌Names.indexOf(normalized));
@@ -88,6 +96,15 @@ const 牌ToName = (牌) => {
 		return `赤${name}`;
 	}
 	return name;
+};
+
+const 牌To採譜表示 = (牌) => {
+	const normalized牌 = 牌.replace(/\uFE00$/, '');
+	const 採譜表示 = 採譜表示s[normalized牌.codePointAt(0) - 0x1F000];
+	if (牌.endsWith('\uFE00')) {
+		return `r${採譜表示}`;
+	}
+	return 採譜表示;
 };
 
 const normalize打牌Command = (text) => {
@@ -502,7 +519,11 @@ module.exports = (clients) => {
 					return;
 				}
 
-				postMessage(state.手牌.join(''));
+				// 12r588m239p467s東白白 のように表記
+				const 採譜表示ed手牌 = state.手牌.map((牌) => 牌To採譜表示(牌)).join('');
+				postMessage(source`
+				${採譜表示ed手牌.slice(0, 採譜表示ed手牌.lastIndexOf('m') + 1).replace(/m/g, '')}m${採譜表示ed手牌.slice(採譜表示ed手牌.lastIndexOf('m') + 1, 採譜表示ed手牌.lastIndexOf('p') + 1).replace(/p/g, '')}p${採譜表示ed手牌.slice(採譜表示ed手牌.lastIndexOf('p') + 1, 採譜表示ed手牌.lastIndexOf('s') + 1).replace(/s/g, '')}s${採譜表示ed手牌.slice(採譜表示ed手牌.lastIndexOf('s') + 1)}
+				`);
 				return;
 			}
 

--- a/mahjong/index.js
+++ b/mahjong/index.js
@@ -503,16 +503,6 @@ module.exports = (clients) => {
 				return;
 			}
 
-			if (text === 'ドラ表示牌') {
-				if (state.phase !== 'gaming') {
-					perdon();
-					return;
-				}
-
-				postMessage(state.ドラ表示牌s.map((牌) => 牌ToName(牌)).join(' '));
-				return;
-			}
-
 			if (text === '手牌表示') {
 				if (state.phase !== 'gaming') {
 					perdon();
@@ -523,6 +513,7 @@ module.exports = (clients) => {
 				const 採譜表示ed手牌 = state.手牌.map((牌) => 牌To採譜表示(牌)).join('');
 				postMessage(source`
 				${採譜表示ed手牌.slice(0, 採譜表示ed手牌.lastIndexOf('m') + 1).replace(/m/g, '')}m${採譜表示ed手牌.slice(採譜表示ed手牌.lastIndexOf('m') + 1, 採譜表示ed手牌.lastIndexOf('p') + 1).replace(/p/g, '')}p${採譜表示ed手牌.slice(採譜表示ed手牌.lastIndexOf('p') + 1, 採譜表示ed手牌.lastIndexOf('s') + 1).replace(/s/g, '')}s${採譜表示ed手牌.slice(採譜表示ed手牌.lastIndexOf('s') + 1)}
+				ドラ表示牌:${state.ドラ表示牌s.map((牌) => 牌ToName(牌)).join(' ')}
 				`);
 				return;
 			}


### PR DESCRIPTION
#502

join, leave の際、同じroomへの/からの join/leave かどうかを判定せずにバグが生まれていたため、バグがないmoveと同じくactionName に roomId を付加して判定する形に修正