### PR TITLE
join, leaveのactionNameにroomIdを追加するように修正

### DIFF
--- a/discord/index.ts
+++ b/discord/index.ts
@@ -186,7 +186,7 @@ export default async ({webClient: slack, eventClient}: SlackInterface) => {
 				const roomName = oldState.channel.name;
 				const roomId = oldState.channel.id;
 				const count = oldState.channel.members.size;
-				const actionName = 'leave';
+				const actionName = `leave-${roomId}`;
 				const update = roomNotifyCache.lastUnixTime + notifyCacheLimit > eventTime && roomNotifyCache.action === actionName;
 
 				if (update) {
@@ -215,7 +215,7 @@ export default async ({webClient: slack, eventClient}: SlackInterface) => {
 				const roomName = newState.channel.name;
 				const roomId = newState.channel.id;
 				const count = newState.channel.members.size;
-				const actionName = 'join';
+				const actionName = `join-${roomId}`;
 				const update = roomNotifyCache.lastUnixTime + notifyCacheLimit > eventTime && roomNotifyCache.action === actionName;
 
 				if (update) {


### PR DESCRIPTION
join, leave の際、同じroomへの/からの join/leave かどうかを判定せずにバグが生まれていたため、バグがないmoveと同じくactionName に roomId を付加して判定する形に修正