### PR TITLE
Fastifyのログをloggerでキャプチャできるよう修正

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -12,7 +12,7 @@ interface RootRoute {
 
 export default () => {
 	const fastify = Fastify({
-		logger: true,
+		logger: logger.child({bot: 'http/api'}),
 		pluginTimeout: 50000,
 	});
 

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ process.on('unhandledRejection', (error: Error, promise: Promise<any>) => {
 sharp.cache(false);
 
 const fastify = Fastify({
+	logger: logger.child({bot: 'http/index'}),
 	pluginTimeout: 50000,
 });
 


### PR DESCRIPTION
Fastifyのloggerオブジェクトに渡すために必要な `fatal`, `trace`, `silent` の3つのログレベルを追加。

ついでに、デバッグ環境でログが送出されたbotを表示するよう修正。

↓こんな感じ

<img width="477" alt="image" src="https://user-images.githubusercontent.com/3126484/217670096-0732b80f-e6a4-4140-b342-141f72ba7b4e.png">
