### PR TITLE
lib/stateを使用しているテストでmockを使用するよう修正

### DIFF
--- a/achievements/index_production.test.ts
+++ b/achievements/index_production.test.ts
@@ -11,6 +11,8 @@ let slack: Slack = null;
 
 jest.mock('../lib/slackUtils');
 
+jest.mock('../lib/state');
+
 jest.mock('../lib/firestore', () => {
 	const firebase = new MockFirebase({});
 	const db = firebase.firestore();

--- a/pocky/index.test.js
+++ b/pocky/index.test.js
@@ -3,6 +3,7 @@
 jest.mock('axios');
 jest.mock('../achievements');
 jest.mock('../lib/slackUtils');
+jest.mock('../lib/state.ts');
 
 const axios = require('axios');
 const pocky = require('./index.js');

--- a/sushi-bot/index.test.js
+++ b/sushi-bot/index.test.js
@@ -1,6 +1,7 @@
 /* eslint-env node, jest */
 jest.mock('../achievements');
 jest.mock('moment');
+jest.mock('../lib/state');
 jest.mock('fs-extra', () => ({
 	mkdirp: jest.fn(),
 	readFile: jest.fn(() => Promise.resolve(Buffer.from(''))),


### PR DESCRIPTION
Jestの open handle error が表示される確率が下がります。たぶん

↓こういうの

```
$ npm test -- achievements

> slackbot@1.0.0 test
> jest --verbose --detectOpenHandles --forceExit achievements

 PASS  achievements/achievements.test.ts (20.418 s)
  achievements
    ✓ all ids are unique (10 ms)
    ✓ all titles are unique (1 ms)
    ✓ no isolated category exists (10 ms)
    ✓ value is defined if counter is defined (21 ms)

 PASS  achievements/index_production.test.ts
  achievements
    ✓ unlock chat achievement when chat is posted (18 ms)

Test Suites: 2 passed, 2 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        21.666 s, estimated 22 s
Ran all test suites matching /achievements/i.

Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  Timeout

      31 | };
      32 |
    > 33 | schedule.scheduleJob('0 * * * *', (date) => {
         |          ^
      34 |         logger.info(`Firestore usage at ${date}: ${inspect(usageCount)}`);
      35 |         usageCount.clear();
      36 | });

      at Timeout.Object.<anonymous>.Timeout.start (node_modules/long-timeout/index.js:41:20)
      at new Timeout (node_modules/long-timeout/index.js:22:8)
      at Object.<anonymous>.exports.setTimeout (node_modules/long-timeout/index.js:5:10)
      at runOnDate (node_modules/node-schedule/lib/Invocation.js:224:13)
      at prepareNextInvocation (node_modules/node-schedule/lib/Invocation.js:251:33)
      at scheduleInvocation (node_modules/node-schedule/lib/Invocation.js:234:3)
      at scheduleNextRecurrence (node_modules/node-schedule/lib/Invocation.js:334:3)
      at Job.Object.<anonymous>.Job.schedule (node_modules/node-schedule/lib/Job.js:218:11)
      at Object.scheduleJob (node_modules/node-schedule/lib/schedule.js:39:11)
      at Object.<anonymous> (lib/state.ts:33:10)
      at Object.<anonymous> (achievements/index_production.ts:11:1)
      at Object.<anonymous> (achievements/index_production.test.ts:8:1)
```