### PR TITLE
refactor: lib/slackMockをTypeScript化

### DIFF
--- a/achievement-quiz/index.test.ts
+++ b/achievement-quiz/index.test.ts
@@ -1,8 +1,7 @@
 import achievementQuiz from './index';
+import Slack from '../lib/slackMock';
 
-const Slack = require('../lib/slackMock.js');
-
-let slack: typeof Slack;
+let slack: Slack;
 
 beforeEach(() => {
   slack = new Slack();

--- a/achievements/index_production.test.ts
+++ b/achievements/index_production.test.ts
@@ -2,8 +2,7 @@
 import noop from 'lodash/noop';
 // @ts-expect-error
 import MockFirebase from 'mock-cloud-firestore';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 
 import achievements from './index_production';
 

--- a/ahokusa/index.test.js
+++ b/ahokusa/index.test.js
@@ -3,7 +3,7 @@
 jest.mock('../achievements');
 
 const ahokusa = require('./index.js');
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 
 let slack = null;
 

--- a/amongyou/index.ts
+++ b/amongyou/index.ts
@@ -1,6 +1,6 @@
 import {constants, promises as fs} from 'fs';
 import path from 'path';
-import type {TeamEventClient} from '../lib/slackEventClient';
+import type {TeamEventClientInterface} from '../lib/slackEventClient';
 import {ChatPostMessageArguments, WebClient} from '@slack/web-api';
 import {stripIndent} from 'common-tags';
 import type {FastifyPluginCallback} from 'fastify';
@@ -131,7 +131,7 @@ const getBlocks = () => [
 ];
 
 class Among {
-	eventClient: TeamEventClient;
+	eventClient: TeamEventClientInterface;
 
 	slack: WebClient;
 
@@ -149,7 +149,7 @@ class Among {
 		slack,
 		slackInteractions,
 	}: {
-		eventClient: TeamEventClient,
+		eventClient: TeamEventClientInterface,
 		slack: WebClient,
 		slackInteractions: any,
 	}) {

--- a/amongyou/index.ts
+++ b/amongyou/index.ts
@@ -1,6 +1,6 @@
 import {constants, promises as fs} from 'fs';
 import path from 'path';
-import type {TeamEventClientInterface} from '../lib/slackEventClient';
+import type {EventEmitter} from 'events';
 import {ChatPostMessageArguments, WebClient} from '@slack/web-api';
 import {stripIndent} from 'common-tags';
 import type {FastifyPluginCallback} from 'fastify';
@@ -131,7 +131,7 @@ const getBlocks = () => [
 ];
 
 class Among {
-	eventClient: TeamEventClientInterface;
+	eventClient: EventEmitter;
 
 	slack: WebClient;
 
@@ -149,7 +149,7 @@ class Among {
 		slack,
 		slackInteractions,
 	}: {
-		eventClient: TeamEventClientInterface,
+		eventClient: EventEmitter,
 		slack: WebClient,
 		slackInteractions: any,
 	}) {

--- a/atequiz/index.ts
+++ b/atequiz/index.ts
@@ -1,5 +1,5 @@
 import { WebAPICallOptions, WebClient } from '@slack/web-api';
-import type { TeamEventClient } from '../lib/slackEventClient';
+import type { TeamEventClientInterface } from '../lib/slackEventClient';
 import { SlackInterface } from '../lib/slack';
 import { ChatPostMessageArguments } from '@slack/web-api/dist/methods';
 import assert from 'assert';
@@ -52,7 +52,7 @@ export const typicalMessageTextsGenerator = {
  * To use other judge/watSecGen/ngReaction, please extend this class.
  */
 export class AteQuiz {
-  eventClient: TeamEventClient;
+  eventClient: TeamEventClientInterface;
   slack: WebClient;
   problem: AteQuizProblem;
   ngReaction: string | null = 'no_good';

--- a/atequiz/index.ts
+++ b/atequiz/index.ts
@@ -1,5 +1,5 @@
 import { WebAPICallOptions, WebClient } from '@slack/web-api';
-import type { TeamEventClientInterface } from '../lib/slackEventClient';
+import type { EventEmitter } from 'events';
 import { SlackInterface } from '../lib/slack';
 import { ChatPostMessageArguments } from '@slack/web-api/dist/methods';
 import assert from 'assert';
@@ -52,7 +52,7 @@ export const typicalMessageTextsGenerator = {
  * To use other judge/watSecGen/ngReaction, please extend this class.
  */
 export class AteQuiz {
-  eventClient: TeamEventClientInterface;
+  eventClient: EventEmitter;
   slack: WebClient;
   problem: AteQuizProblem;
   ngReaction: string | null = 'no_good';

--- a/channel-notifier/index.test.js
+++ b/channel-notifier/index.test.js
@@ -2,7 +2,7 @@
 
 jest.mock('axios');
 
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 const channelNotifier = require('./index.js');
 
 let slack = null;

--- a/checkin/index.test.js
+++ b/checkin/index.test.js
@@ -3,7 +3,7 @@
 jest.mock('axios');
 
 const axios = require('axios');
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 const checkin = require('./index.js');
 
 let slack = null;

--- a/dajare/index.test.js
+++ b/dajare/index.test.js
@@ -5,7 +5,7 @@ jest.mock('./tokenize.js');
 jest.mock('../achievements');
 
 const dajare = require('./index.js');
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 const tokenize = require('./tokenize.js');
 
 tokenize.virtualTokens = {

--- a/discord/hayaoshiUtils.test.ts
+++ b/discord/hayaoshiUtils.test.ts
@@ -3,6 +3,11 @@
 import {inspect} from 'util';
 import {extractValidAnswers} from './hayaoshiUtils';
 
+jest.mock('../hayaoshi', () => ({
+	isCorrectAnswer: jest.fn(),
+	normalize: jest.fn(),
+}));
+
 const testCases: [string, string, string[]][] = [
 	['', 'リトグラフ[lithograph]【「石版画」「石版印刷」「リトグラフィー[lithographie]」も○】',
 		['リトグラフ', 'lithograph', '石版画', '石版印刷', 'リトグラフィー', 'lithographie'],

--- a/emoji-notifier/index.test.js
+++ b/emoji-notifier/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-env node, jest */
 
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 const emojiNotifier = require('./index.js');
 
 let slack = null;

--- a/hitandblow/index.test.ts
+++ b/hitandblow/index.test.ts
@@ -2,7 +2,7 @@ import { stripIndent } from 'common-tags';
 import hitandblow from './';
 import Slack from '../lib/slackMock';
 
-let slack: typeof Slack;
+let slack: Slack;
 
 beforeEach(() => {
   slack = new Slack();

--- a/hitandblow/index.test.ts
+++ b/hitandblow/index.test.ts
@@ -1,7 +1,6 @@
 import { stripIndent } from 'common-tags';
 import hitandblow from './';
-
-const Slack = require('../lib/slackMock.js');
+import Slack from '../lib/slackMock';
 
 let slack: typeof Slack;
 

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -3,7 +3,7 @@ import { range, shuffle, round } from 'lodash';
 import { stripIndent } from 'common-tags';
 import { unlock } from '../achievements';
 import assert from 'assert';
-import type { TeamEventClientInterface } from '../lib/slackEventClient';
+import type { EventEmitter } from 'events';
 
 interface HitAndBlowHistory {
   call: number[];
@@ -90,7 +90,7 @@ export default ({
   eventClient,
   webClient: slack,
 }: {
-  eventClient: TeamEventClientInterface;
+  eventClient: EventEmitter;
   webClient: WebClient;
 }) => {
   const state = new HitAndBlowState();

--- a/hitandblow/index.ts
+++ b/hitandblow/index.ts
@@ -1,9 +1,9 @@
-import { SlackEventAdapter } from '@slack/events-api';
 import { WebClient } from '@slack/web-api';
 import { range, shuffle, round } from 'lodash';
 import { stripIndent } from 'common-tags';
 import { unlock } from '../achievements';
 import assert from 'assert';
+import type { TeamEventClientInterface } from '../lib/slackEventClient';
 
 interface HitAndBlowHistory {
   call: number[];
@@ -17,7 +17,7 @@ class HitAndBlowState {
   thread: string | null = null;
   startDate: number | null = null;
   timer: NodeJS.Timeout | null = null;
-  inGame: boolean = false;
+  inGame = false;
   clear() {
     this.answer = [];
     this.history = [];
@@ -90,7 +90,7 @@ export default ({
   eventClient,
   webClient: slack,
 }: {
-  eventClient: SlackEventAdapter;
+  eventClient: TeamEventClientInterface;
   webClient: WebClient;
 }) => {
   const state = new HitAndBlowState();

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -5,13 +5,13 @@ import sql from 'sql-template-strings';
 import * as sqlite from 'sqlite';
 import sqlite3 from 'sqlite3';
 import path from 'path';
-import {TeamEventClient} from './slackEventClient';
+import {TeamEventClient, TeamEventClientInterface} from './slackEventClient';
 import {Deferred} from './utils';
 import {Token} from '../oauth/tokens';
 
 export interface SlackInterface {
 	webClient: WebClient;
-	eventClient: TeamEventClient;
+	eventClient: TeamEventClientInterface;
 	messageClient: ReturnType<typeof createMessageAdapter>;
 };
 

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -5,13 +5,14 @@ import sql from 'sql-template-strings';
 import * as sqlite from 'sqlite';
 import sqlite3 from 'sqlite3';
 import path from 'path';
-import {TeamEventClient, TeamEventClientInterface} from './slackEventClient';
+import {TeamEventClient} from './slackEventClient';
+import type {EventEmitter} from 'events';
 import {Deferred} from './utils';
 import {Token} from '../oauth/tokens';
 
 export interface SlackInterface {
 	webClient: WebClient;
-	eventClient: TeamEventClientInterface;
+	eventClient: EventEmitter;
 	messageClient: ReturnType<typeof createMessageAdapter>;
 };
 

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -12,7 +12,7 @@ import {Token} from '../oauth/tokens';
 
 export interface SlackInterface {
 	webClient: WebClient;
-	eventClient: EventEmitter;
+	eventClient: EventEmitter & Pick<TeamEventClient, keyof TeamEventClient>;
 	messageClient: ReturnType<typeof createMessageAdapter>;
 };
 

--- a/lib/slackCache.test.ts
+++ b/lib/slackCache.test.ts
@@ -8,7 +8,6 @@ import type {
 	EmojiListArguments,
 	EmojiListResponse,
 } from '@slack/web-api';
-// @ts-expect-error
 import Slack from './slackMock';
 import SlackCache from './slackCache';
 

--- a/lib/slackCache.ts
+++ b/lib/slackCache.ts
@@ -1,7 +1,8 @@
 import {get} from 'lodash';
+import type {EventEmitter} from 'events';
 import type {Token} from '../oauth/tokens';
 import {Deferred} from './utils';
-import {TeamEventClient, TeamEventClientInterface} from './slackEventClient';
+import {TeamEventClient} from './slackEventClient';
 import logger from './logger';
 
 import type {Reaction} from '@slack/web-api/dist/response/ConversationsHistoryResponse';
@@ -31,7 +32,7 @@ interface WebClient {
 
 interface Config {
 	token: Token;
-	eventClient: TeamEventClientInterface;
+	eventClient: EventEmitter;
 	webClient: WebClient;
 	enableReactions?: boolean;
 }

--- a/lib/slackCache.ts
+++ b/lib/slackCache.ts
@@ -1,10 +1,9 @@
 import {get} from 'lodash';
 import type {Token} from '../oauth/tokens';
 import {Deferred} from './utils';
-import {TeamEventClient} from './slackEventClient';
+import {TeamEventClient, TeamEventClientInterface} from './slackEventClient';
 import logger from './logger';
 
-import type {SlackEventAdapter} from '@slack/events-api';
 import type {Reaction} from '@slack/web-api/dist/response/ConversationsHistoryResponse';
 import type {Member} from '@slack/web-api/dist/response/UsersListResponse';
 import type {
@@ -32,7 +31,7 @@ interface WebClient {
 
 interface Config {
 	token: Token;
-	eventClient: SlackEventAdapter;
+	eventClient: TeamEventClientInterface;
 	webClient: WebClient;
 	enableReactions?: boolean;
 }

--- a/lib/slackEventClient.ts
+++ b/lib/slackEventClient.ts
@@ -1,8 +1,8 @@
 import type {EventEmitter} from 'events';
 
 export class TeamEventClient {
-	#eventAdapter: EventEmitter;
-	#team: string;
+	readonly #eventAdapter: EventEmitter;
+	readonly #team: string;
 
 	// contract: 渡されるeventAdapterは、EventAdapterOptions.includeBodyがtrueでなければならない。
 	constructor(eventAdapter: EventEmitter, team: string) {
@@ -29,6 +29,3 @@ export class TeamEventClient {
 
 	// feel free to add any other [Events](https://nodejs.org/api/events.html) methods you want!
 }
-
-// https://stackoverflow.com/a/48953930
-export type TeamEventClientInterface = Pick<TeamEventClient, keyof TeamEventClient>;

--- a/lib/slackEventClient.ts
+++ b/lib/slackEventClient.ts
@@ -1,11 +1,11 @@
-import type {SlackEventAdapter} from '@slack/events-api';
+import type {EventEmitter} from 'events';
 
 export class TeamEventClient {
-	#eventAdapter: SlackEventAdapter;
+	#eventAdapter: EventEmitter;
 	#team: string;
 
 	// contract: 渡されるeventAdapterは、EventAdapterOptions.includeBodyがtrueでなければならない。
-	constructor(eventAdapter: SlackEventAdapter, team: string) {
+	constructor(eventAdapter: EventEmitter, team: string) {
 		this.#eventAdapter = eventAdapter;
 		this.#team = team;
 	}

--- a/lib/slackEventClient.ts
+++ b/lib/slackEventClient.ts
@@ -1,27 +1,27 @@
 import type {SlackEventAdapter} from '@slack/events-api';
 
 export class TeamEventClient {
-	private readonly eventAdapter: SlackEventAdapter;
-	private readonly team: string;
+	#eventAdapter: SlackEventAdapter;
+	#team: string;
 
 	// contract: 渡されるeventAdapterは、EventAdapterOptions.includeBodyがtrueでなければならない。
 	constructor(eventAdapter: SlackEventAdapter, team: string) {
-		this.eventAdapter = eventAdapter;
-		this.team = team;
+		this.#eventAdapter = eventAdapter;
+		this.#team = team;
 	}
 
 	// listen on events against all teams.
 	onAllTeam(event: string, listener: (...args: any[]) => void): any {
-		return this.eventAdapter.on(event, listener);
+		return this.#eventAdapter.on(event, listener);
 	}
 	// listen on events against the team.
 	on(event: string, listener: (...args: any[]) => void): any {
-		return this.eventAdapter.on(event, (...args: any[]) => {
+		return this.#eventAdapter.on(event, (...args: any[]) => {
 			// https://slack.dev/node-slack-sdk/events-api#receive-additional-event-data
 			// https://github.com/slackapi/node-slack-sdk/blob/3e9c483c593d6aa28f6f5680f287722df3327609/packages/events-api/src/http-handler.ts#L212-L223
 			// https://api.slack.com/apis/connections/events-api#the-events-api__receiving-events__events-dispatched-as-json
 			// args: [body.event, body: {team_id: string}]
-			if (args[1].team_id === this.team) {
+			if (args[1].team_id === this.#team) {
 				listener(...args);
 			}
 		});
@@ -29,3 +29,6 @@ export class TeamEventClient {
 
 	// feel free to add any other [Events](https://nodejs.org/api/events.html) methods you want!
 }
+
+// https://stackoverflow.com/a/48953930
+export type TeamEventClientInterface = Pick<TeamEventClient, keyof TeamEventClient>;

--- a/lib/slackMock.ts
+++ b/lib/slackMock.ts
@@ -1,10 +1,9 @@
 /* eslint-env node, jest */
 
-import type {ChatPostMessageArguments, ChatPostMessageResponse, ReactionsAddArguments, ReactionsAddResponse, WebClient} from '@slack/web-api';
+import type {ChatPostMessageArguments, ReactionsAddArguments, WebClient} from '@slack/web-api';
 import {EventEmitter} from 'events';
 import {noop, last} from 'lodash';
 import type {SlackInterface} from './slack';
-import { TeamEventClient, TeamEventClientInterface } from './slackEventClient';
 
 // https://jestjs.io/docs/mock-function-api
 const mockMethodCalls = [
@@ -46,8 +45,10 @@ const createWebClient = (
 				if (isMockMethodCall(methodName)) {
 					const mock = jest.fn();
 					registeredMocks.set(stack.slice(0, -1).join('.'), mock);
-					const mockArgs = args as Parameters<typeof mock['mockImplementation']>;
-					return mock[methodName](...mockArgs);
+					return mock[methodName](
+						// @ts-expect-error: Spread operator is not supported.
+						...args,
+					);
 				}
 				return fallbackFn(stack, ...args)
 			},
@@ -81,7 +82,7 @@ export default class SlackMock extends EventEmitter implements SlackInterface {
 	fakeTeam = 'T00000000';
 	fakeTimestamp = '1234567890.123456';
 
-	readonly eventClient: TeamEventClientInterface & EventEmitter;
+	readonly eventClient: EventEmitter;
 	readonly registeredMocks: Map<string, jest.Mock>;
 	readonly webClient: WebClient;
 	readonly messageClient: any;

--- a/lib/slackMock.ts
+++ b/lib/slackMock.ts
@@ -82,7 +82,7 @@ export default class SlackMock extends EventEmitter implements SlackInterface {
 	fakeTeam = 'T00000000';
 	fakeTimestamp = '1234567890.123456';
 
-	readonly eventClient: EventEmitter;
+	readonly eventClient: MockTeamEventClient;
 	readonly registeredMocks: Map<string, jest.Mock>;
 	readonly webClient: WebClient;
 	readonly messageClient: any;

--- a/lib/slackMock.ts
+++ b/lib/slackMock.ts
@@ -1,8 +1,10 @@
 /* eslint-env node, jest */
 
-const EventEmitter = require('events');
-const noop = require('lodash/noop');
-const last = require('lodash/last');
+import type {ChatPostMessageArguments, ChatPostMessageResponse, ReactionsAddArguments, ReactionsAddResponse, WebClient} from '@slack/web-api';
+import {EventEmitter} from 'events';
+import {noop, last} from 'lodash';
+import type {SlackInterface} from './slack';
+import { TeamEventClient, TeamEventClientInterface } from './slackEventClient';
 
 // https://jestjs.io/docs/mock-function-api
 const mockMethodCalls = [
@@ -19,20 +21,33 @@ const mockMethodCalls = [
 	'mockClear',
 	'mockReset',
 	'mockName',
-];
+] as const;
 
-const createWebClient = (fallbackFn, registeredMocks) => {
-	const handler = (stack) => {
+const isMockMethodCall = (name: string): name is (typeof mockMethodCalls)[number] => (
+	(mockMethodCalls as readonly string[]).includes(name)
+);
+
+interface MockWebClient extends Record<string, MockWebClient> {
+	(...args: any[]): any;
+}
+
+const createWebClient = (
+	fallbackFn: (stack: string[], ...args: any[]) => Promise<any>,
+	registeredMocks: Map<string, jest.Mock>,
+) => {
+	const handler = (stack: string[]): MockWebClient => {
 		return new Proxy(
-			(...args) => {
+			(...args: any[]) => {
 				const path = stack.join('.');
+				const methodName = last(stack);
 				if (registeredMocks.has(path)) {
 					return registeredMocks.get(path)(...args);
 				}
-				if (mockMethodCalls.includes(last(stack))) {
+				if (isMockMethodCall(methodName)) {
 					const mock = jest.fn();
 					registeredMocks.set(stack.slice(0, -1).join('.'), mock);
-					return mock[last(stack)](...args);
+					const mockArgs = args as Parameters<typeof mock['mockImplementation']>;
+					return mock[methodName](...mockArgs);
 				}
 				return fallbackFn(stack, ...args)
 			},
@@ -48,66 +63,82 @@ const createWebClient = (fallbackFn, registeredMocks) => {
 					return Reflect.get(name, property, receiver);
 				},
 			}
-		);
+		) as MockWebClient;
 	};
 
 	return handler([]);
 };
 
-module.exports = class SlackMock extends EventEmitter {
-	constructor(...args) {
-		super(...args);
-		this.fakeChannel = 'C00000000';
-		this.fakeUser = 'U00000000';
-		this.fakeTimestamp = '1234567890.123456';
-		this.eventClient = new EventEmitter();
+class MockTeamEventClient extends EventEmitter {
+	onAllTeam(event: string, listener: (...args: any[]) => void): any {
+		return this.on(event, listener);
+	}
+}
+
+export default class SlackMock extends EventEmitter implements SlackInterface {
+	fakeChannel = 'C00000000';
+	fakeUser = 'U00000000';
+	fakeTeam = 'T00000000';
+	fakeTimestamp = '1234567890.123456';
+
+	readonly eventClient: TeamEventClientInterface & EventEmitter;
+	readonly registeredMocks: Map<string, jest.Mock>;
+	readonly webClient: WebClient;
+	readonly messageClient: any;
+
+	constructor() {
+		super();
+		this.eventClient = new MockTeamEventClient();
 		this.registeredMocks = new Map();
-		this.webClient = createWebClient((...args) => this.handleWebcall(...args), this.registeredMocks);
+		this.webClient = createWebClient(
+			(stack: string[], ...args: any[]) => this.handleWebcall(stack, ...args),
+			this.registeredMocks,
+		) as unknown as WebClient;
 		this.messageClient = {
 			action: noop,
 			viewSubmission: noop,
 		};
 	}
 
-	handleWebcall(stack, ...args) {
+	handleWebcall(stack: string[], ...args: any[]) {
 		this.emit('webcall', stack, ...args);
 		this.emit(stack.join('.'), ...args);
 		if (stack.join('.') === "emoji.list") {
 			return Promise.resolve({ok: true, emoji: {"fakeemoji": "https://example.com"}});
 		}
 		if (stack.join('.') === "users.list") {
-			return {members: []}
+			return Promise.resolve({ok: true, members: []});
 		}
 		if (stack.join('.') === "conversations.list") {
 			return Promise.resolve({ok: true, channels: [
 				{id: 'CGENERAL', is_general: true},
 			]});
 		}
-		if (stack.join('.') ===  "chat.postMessage") {
+		if (stack.join('.') === "chat.postMessage") {
 			return Promise.resolve({ok: true, ts: this.fakeTimestamp});
 		}
-		if (stack.join('.') ===  "chat.unfurl") {
+		if (stack.join('.') === "chat.unfurl") {
 			return Promise.resolve({ok: true});
 		}
 		// TODO: make returned value customizable
 		return Promise.resolve([]);
 	}
 
-	postMessage(message, options={}) {
+	postMessage(message: string, options = {}) {
 		const data = {
 			channel: this.fakeChannel,
 			text: message,
 			user: this.fakeUser,
 			ts: this.fakeTimestamp,
-			type: "message",
+			type: 'message',
 			...options
 		};
 		this.eventClient.emit('message', data);
 	}
 
-	waitForEvent(eventName){
+	waitForEvent(eventName: string) {
 		return new Promise((resolve) => {
-			const handleResponse = (options) => {
+			const handleResponse = (options: {channel: string} & Record<string, any>) => {
 				if (options.channel === this.fakeChannel) {
 					this.removeListener(eventName, handleResponse);
 					resolve(options);
@@ -119,14 +150,14 @@ module.exports = class SlackMock extends EventEmitter {
 	}
 
 	waitForResponse() {
-		return this.waitForEvent('chat.postMessage');
+		return this.waitForEvent('chat.postMessage') as Promise<ChatPostMessageArguments>;
 	}
 
 	waitForReaction() {
-		return this.waitForEvent('reactions.add');
+		return this.waitForEvent('reactions.add') as Promise<ReactionsAddArguments>;
 	}
 
-	getResponseTo(message, options={}) {
+	getResponseTo(message: string, options = {}) {
 		const res = this.waitForResponse();
 		this.postMessage(message, options);
 		return res;
@@ -134,7 +165,6 @@ module.exports = class SlackMock extends EventEmitter {
 
 	// Not recommended. Instanciate a new SlackMock instead.
 	reset() {
-		this.eventClient.removeAllListeners();
 		this.removeAllListeners();
 		this.registeredMocks.clear();
 	}

--- a/lib/slackUtils.ts
+++ b/lib/slackUtils.ts
@@ -100,7 +100,7 @@ export const mrkdwn = (text: string): MrkdwnElement => ({
 
 const isGenericMessage = (message: MessageEvent): message is GenericMessageEvent => (
 	message.subtype === undefined
-)
+);
 
 export const extractMessage = (message: MessageEvent) => {
 	if (isGenericMessage(message)) {

--- a/lyrics/index.test.ts
+++ b/lyrics/index.test.ts
@@ -2,8 +2,7 @@ jest.mock('tinyreq');
 jest.mock('axios');
 
 import lyrics from './index';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 // @ts-expect-error
 import tinyreq from 'tinyreq';
 import axios from 'axios';

--- a/mahjong/index.test.js
+++ b/mahjong/index.test.js
@@ -2,7 +2,7 @@
 
 jest.mock('../achievements');
 
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 const mahjong = require('./index.js');
 
 let slack = null;

--- a/map-guessr/index.ts
+++ b/map-guessr/index.ts
@@ -9,7 +9,7 @@ import {
   WebClient,
 } from "@slack/web-api";
 import { increment } from "../achievements";
-import { TeamEventClient } from "../lib/slackEventClient";
+import { TeamEventClientInterface } from "../lib/slackEventClient";
 const { Mutex } = require("async-mutex");
 const { AteQuiz } = require("../atequiz/index.ts");
 const cloudinary = require("cloudinary");
@@ -39,7 +39,7 @@ class CoordAteQuiz extends AteQuiz {
   static option?: WebAPICallOptions = postOptions;
   ngReaction: string | null = null;
   constructor(
-    eventClient: TeamEventClient,
+    eventClient: TeamEventClientInterface,
     slack: WebClient,
     problem: CoordAteQuizProblem
   ) {

--- a/map-guessr/index.ts
+++ b/map-guessr/index.ts
@@ -9,7 +9,7 @@ import {
   WebClient,
 } from "@slack/web-api";
 import { increment } from "../achievements";
-import { TeamEventClientInterface } from "../lib/slackEventClient";
+import { EventEmitter } from 'events';
 const { Mutex } = require("async-mutex");
 const { AteQuiz } = require("../atequiz/index.ts");
 const cloudinary = require("cloudinary");
@@ -39,7 +39,7 @@ class CoordAteQuiz extends AteQuiz {
   static option?: WebAPICallOptions = postOptions;
   ngReaction: string | null = null;
   constructor(
-    eventClient: TeamEventClientInterface,
+    eventClient: EventEmitter,
     slack: WebClient,
     problem: CoordAteQuizProblem
   ) {

--- a/octas/index.test.ts
+++ b/octas/index.test.ts
@@ -1,9 +1,7 @@
 jest.mock('cloudinary');
 
 import octas from './index';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
-import { List } from 'lodash';
+import Slack from '../lib/slackMock';
 
 let slack: Slack = null;
 
@@ -15,7 +13,7 @@ beforeEach(async () => {
 
 describe('octas', () => {
     it('respond to octas', async () => {
-        const { channel, text, attachments }: { channel: string, text: string, attachments: List<any> } = await slack.getResponseTo('octas');
+        const { channel, text, attachments } = await slack.getResponseTo('octas');
 
         expect(channel).toBe(slack.fakeChannel);
         expect(text).toContain('Octas対人を始めるよ～');

--- a/oogiri/index.ts
+++ b/oogiri/index.ts
@@ -4,7 +4,6 @@
 // eslint-disable-next-line no-unused-vars
 import {constants, promises as fs} from 'fs';
 import path from 'path';
-import type {TeamEventClient} from '../lib/slackEventClient';
 import type {KnownBlock, WebClient} from '@slack/web-api';
 import {Mutex} from 'async-mutex';
 import {stripIndent} from 'common-tags';
@@ -12,6 +11,7 @@ import type {FastifyPluginCallback} from 'fastify';
 import plugin from 'fastify-plugin';
 import {flatten, isEmpty, range, shuffle, times, uniq} from 'lodash';
 import type {SlackInterface, SlashCommandEndpoint} from '../lib/slack';
+import type {TeamEventClientInterface} from '../lib/slackEventClient';
 import {getMemberName} from '../lib/slackUtils';
 import {Deferred} from '../lib/utils';
 
@@ -47,7 +47,7 @@ interface State {
 const mutex = new Mutex();
 
 class Oogiri {
-	eventClient: TeamEventClient;
+	eventClient: TeamEventClientInterface;
 
 	slack: WebClient;
 
@@ -64,7 +64,7 @@ class Oogiri {
 		slack,
 		slackInteractions,
 	}: {
-		eventClient: TeamEventClient,
+		eventClient: TeamEventClientInterface,
 		slack: WebClient,
 		slackInteractions: any,
 	}) {
@@ -203,7 +203,7 @@ class Oogiri {
 		return this.loadDeferred.promise;
 	}
 
-	showStartDialog(triggerId: string, text: string = '') {
+	showStartDialog(triggerId: string, text = '') {
 		if (this.state.games.length >= 3) {
 			return '大喜利を同時に3つ以上開催することはできないよ:imp:';
 		}
@@ -285,7 +285,7 @@ class Oogiri {
 		await this.setState({games: this.state.games});
 	}
 
-	async getMeaningBlocks(game: Game, compact: boolean = false): Promise<KnownBlock[]> {
+	async getMeaningBlocks(game: Game, compact = false): Promise<KnownBlock[]> {
 		const registrants = await Promise.all(uniq(game.meanings.map((meaning) => meaning.user)).map((user) => getMemberName(user)));
 
 		return [
@@ -386,7 +386,7 @@ class Oogiri {
 						hint: '後から変更できます',
 					},
 					...(range(game.maxMeanings - 1).map((i) => ({
-						type: 'text' as ('text'),
+						type: 'text' as const,
 						label: `${i + 2}個目`,
 						name: `meaning${i + 2}`,
 						min_length: 3,
@@ -481,7 +481,7 @@ class Oogiri {
 		await this.setState({games: this.state.games});
 	}
 
-	async getBettingBlocks(game: Game, compact: boolean = false): Promise<KnownBlock[]> {
+	async getBettingBlocks(game: Game, compact = false): Promise<KnownBlock[]> {
 		const mentions = uniq(game.meanings.map((meaning) => `<@${meaning.user}>`));
 		const betters = await Promise.all(Object.keys(game.bettings).map((user) => getMemberName(user)));
 

--- a/oogiri/index.ts
+++ b/oogiri/index.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-restricted-imports */
 /* eslint-disable react/no-access-state-in-setstate */
 // eslint-disable-next-line no-unused-vars
+import type {EventEmitter} from 'events';
 import {constants, promises as fs} from 'fs';
 import path from 'path';
 import type {KnownBlock, WebClient} from '@slack/web-api';
@@ -11,7 +12,6 @@ import type {FastifyPluginCallback} from 'fastify';
 import plugin from 'fastify-plugin';
 import {flatten, isEmpty, range, shuffle, times, uniq} from 'lodash';
 import type {SlackInterface, SlashCommandEndpoint} from '../lib/slack';
-import type {TeamEventClientInterface} from '../lib/slackEventClient';
 import {getMemberName} from '../lib/slackUtils';
 import {Deferred} from '../lib/utils';
 
@@ -47,7 +47,7 @@ interface State {
 const mutex = new Mutex();
 
 class Oogiri {
-	eventClient: TeamEventClientInterface;
+	eventClient: EventEmitter;
 
 	slack: WebClient;
 
@@ -64,7 +64,7 @@ class Oogiri {
 		slack,
 		slackInteractions,
 	}: {
-		eventClient: TeamEventClientInterface,
+		eventClient: EventEmitter,
 		slack: WebClient,
 		slackInteractions: any,
 	}) {

--- a/pocky/index.test.js
+++ b/pocky/index.test.js
@@ -7,7 +7,7 @@ jest.mock('../lib/state.ts');
 
 const axios = require('axios');
 const pocky = require('./index.js');
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 
 let slack = null;
 

--- a/ponpe/index.test.ts
+++ b/ponpe/index.test.ts
@@ -15,8 +15,7 @@ fs.virtualFiles = {
 };
 
 import ponpe from './index';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 
 let slack: Slack = null;
 

--- a/prime/index.test.js
+++ b/prime/index.test.js
@@ -2,7 +2,7 @@
 
 jest.mock('../achievements');
 
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 const shogi = require('./index.js');
 
 let slack = null;

--- a/pwnyaa/index.test.ts
+++ b/pwnyaa/index.test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable no-undef */
 import {constants, promises as fs} from 'fs';
 import path from 'path';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 import {getMemberName} from '../lib/slackUtils';
 import {Challenge, SolvedInfo, Profile} from './lib/BasicTypes';
 import {fetchChallsCH, fetchUserProfileCH} from './lib/CHManager';
@@ -231,7 +230,7 @@ beforeEach(async () => {
 
 
 it('respond to usage', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa usage');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa usage');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('list');
@@ -240,7 +239,7 @@ it('respond to usage', async () => {
 });
 
 it('respond to help', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa help');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa help');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('list');
@@ -249,13 +248,13 @@ it('respond to help', async () => {
 });
 
 it('respond to list', async () => {
-	const {channel}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa list');
+	const {channel} = await slack.getResponseTo('@pwnyaa list');
 
 	expect(channel).toBe(slack.fakeChannel);
 });
 
 it('respond to check tw', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa check tw');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa check tw');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('azaika');
@@ -264,27 +263,27 @@ it('respond to check tw', async () => {
 });
 
 it('respond to check xyz without joining', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa check xyz');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa check xyz');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('参加してないよ');
 });
 
 it('respond to check ch without joining', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa check ch');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa check ch');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('参加してないよ');
 });
 it('respond to check ksn without joining', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa check ksn');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa check ksn');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('参加してないよ');
 });
 
 it('respond to check', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa check');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa check');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('check');
@@ -292,14 +291,14 @@ it('respond to check', async () => {
 });
 
 it('respond to join hoge fuga', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa join hoge fuga');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa join hoge fuga');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('は見つからなかったよ');
 });
 
 it('respond to join tw', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa join tw');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa join tw');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('join');
@@ -307,7 +306,7 @@ it('respond to join tw', async () => {
 });
 
 it('respond to join xyz', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa join xyz');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa join xyz');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('join');
@@ -315,7 +314,7 @@ it('respond to join xyz', async () => {
 });
 
 it('respond to join ch', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa join ch');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa join ch');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('join');
@@ -323,7 +322,7 @@ it('respond to join ch', async () => {
 });
 
 it('respond to join ksn', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa join ksn');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa join ksn');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('join');
@@ -331,7 +330,7 @@ it('respond to join ksn', async () => {
 });
 
 it('respond to stat', async () => {
-	const {channel, text}: { channel: string, text: string } = await slack.getResponseTo('@pwnyaa stat');
+	const {channel, text} = await slack.getResponseTo('@pwnyaa stat');
 
 	expect(channel).toBe(slack.fakeChannel);
 	expect(text).toContain('状況だよ');

--- a/remember-english/index.test.ts
+++ b/remember-english/index.test.ts
@@ -5,8 +5,7 @@ jest.mock('../lib/slackUtils');
 jest.mock('../lib/state');
 
 import type {KnownBlock, WebAPICallResult, ViewsOpenArguments} from '@slack/web-api';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 import {RememberEnglish} from '.';
 
 let slack: Slack = null;
@@ -47,7 +46,7 @@ beforeEach(async () => {
 		.useFakeTimers()
 		.setSystemTime(now);
 
-	rememberEnglish = new MockedRememberEnglish(slack);
+	rememberEnglish = new MockedRememberEnglish({slack: slack.webClient});
 	await rememberEnglish.initialize();
 });
 

--- a/ricochet-robots/index.test.js
+++ b/ricochet-robots/index.test.js
@@ -8,7 +8,7 @@ const cloudinary = require('cloudinary');
 const rust_proxy = require('./rust-proxy.js');
 
 const hyperrobot = require('./index.js');
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 
 const fs = require('fs');
 const path = require('path');

--- a/room-gacha/index.test.ts
+++ b/room-gacha/index.test.ts
@@ -7,7 +7,7 @@ import tinyreq from 'tinyreq';
 import { promises as fs } from 'fs';
 import { stripIndents } from 'common-tags';
 import assert from 'assert';
-import type { Block, KnownBlock } from '@slack/web-api';
+import type { KnownBlock } from '@slack/web-api';
 
 let slack: Slack = null;
 
@@ -30,17 +30,22 @@ describe('room-gacha', () => {
         expect(response.text).toBe('物件ガチャの結果だよ〜:full_moon_with_face:');
 
         const block0 = response.blocks[0] as KnownBlock;
-        expect(block0.type).toBe('section');
         assert(block0.type === 'section');
         expect(block0.text.text).toBe('*東京都文京区の賃貸住宅[賃貸マンション・アパート]情報* (12,345件) から選んだよ〜 :full_moon_with_face:');
-        expect(response.blocks[3].text.text).toBe(stripIndents`*<https://suumo.jp/chintai/bc_000000000000/|ザ・シェアハウス地下>*
+
+        const block3 = response.blocks[3] as KnownBlock;
+        assert(block3.type === 'section');
+        expect(block3.text.text).toBe(stripIndents`*<https://suumo.jp/chintai/bc_000000000000/|ザ・シェアハウス地下>*
             *住所*: 東京都文京区本郷７丁目３−１
             *アクセス*: 本郷三丁目駅（地下鉄丸の内線）より徒歩8分
             本郷三丁目駅（地下鉄大江戸線）より徒歩6分
             湯島駅又は根津駅（地下鉄千代田線）より徒歩8分
             東大前駅（地下鉄南北線）より徒歩1分
             春日駅（地下鉄三田線）より徒歩10分`);
-        expect(response.blocks[4].fields.map(
+
+        const block4 = response.blocks[4] as KnownBlock;
+        assert(block4.type === 'section');
+        expect(block4.fields.map(
             (field: {type: string; text: string; }) => field.text
         )).toMatchObject([
             '*家賃*\n123.4万円',
@@ -49,6 +54,9 @@ describe('room-gacha', () => {
             '*向き*\n南東',
             '*築年数*\n築100年',
         ]);
-        expect(response.blocks[5].image_url).toBe('https://img01.suumo.com/front/gazo/fr/bukken/000/000000000000/000000000000_ef.jpg');
+
+        const block5 = response.blocks[5] as KnownBlock;
+        assert(block5.type === 'image');
+        expect(block5.image_url).toBe('https://img01.suumo.com/front/gazo/fr/bukken/000/000000000000/000000000000_ef.jpg');
     });
 });

--- a/room-gacha/index.test.ts
+++ b/room-gacha/index.test.ts
@@ -1,12 +1,13 @@
 jest.mock('tinyreq');
 
 import roomGacha from './index';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 // @ts-expect-error
 import tinyreq from 'tinyreq';
 import { promises as fs } from 'fs';
 import { stripIndents } from 'common-tags';
+import assert from 'assert';
+import type { Block, KnownBlock } from '@slack/web-api';
 
 let slack: Slack = null;
 
@@ -27,7 +28,11 @@ describe('room-gacha', () => {
         expect(response.username).toBe('物件ガチャ');
         expect(response.icon_emoji).toBe(':house:');
         expect(response.text).toBe('物件ガチャの結果だよ〜:full_moon_with_face:');
-        expect(response.blocks[0].text.text).toBe('*東京都文京区の賃貸住宅[賃貸マンション・アパート]情報* (12,345件) から選んだよ〜 :full_moon_with_face:');
+
+        const block0 = response.blocks[0] as KnownBlock;
+        expect(block0.type).toBe('section');
+        assert(block0.type === 'section');
+        expect(block0.text.text).toBe('*東京都文京区の賃貸住宅[賃貸マンション・アパート]情報* (12,345件) から選んだよ〜 :full_moon_with_face:');
         expect(response.blocks[3].text.text).toBe(stripIndents`*<https://suumo.jp/chintai/bc_000000000000/|ザ・シェアハウス地下>*
             *住所*: 東京都文京区本郷７丁目３−１
             *アクセス*: 本郷三丁目駅（地下鉄丸の内線）より徒歩8分

--- a/scrapbox/index.test.ts
+++ b/scrapbox/index.test.ts
@@ -1,7 +1,6 @@
 import type {ChatUnfurlArguments} from '@slack/web-api';
 import axios from 'axios';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 import scrapbox, {scrapbox2slack} from './index';
 
 jest.mock('axios');

--- a/shogi/index.test.js
+++ b/shogi/index.test.js
@@ -5,7 +5,7 @@ jest.mock('sqlite');
 
 const cloudinary = require('cloudinary');
 const sqlite = require('sqlite');
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 const shogi = require('./index.js');
 
 let slack = null;

--- a/slack-log/index.test.ts
+++ b/slack-log/index.test.ts
@@ -1,8 +1,7 @@
 import type {ChatUnfurlArguments} from '@slack/web-api';
 import axios from 'axios';
 import slacklog from './index';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 
 jest.mock('axios');
 
@@ -24,7 +23,7 @@ beforeEach(async () => {
 
 describe('slacklog', () => {
 	it('respond to slacklog url request', async () => {
-		const {channel, text}: {channel: string, text: string} = await slack.getResponseTo('slacklog');
+		const {channel, text} = await slack.getResponseTo('slacklog');
 
 		expect(channel).toBe(slack.fakeChannel);
 		expect(text).toMatch('slack-log.tsg.ne.jp');
@@ -33,7 +32,7 @@ describe('slacklog', () => {
 
 	it('respond to canonical slacklog-ize request', async () => {
 		const requestURL: string = '<https://tsg-ut.slack.com/archives/C0123ABCD/p1501234567890123>';
-		const {channel, text}: {channel: string, text: string} = await slack.getResponseTo(`slacklog ${requestURL}`);
+		const {channel, text} = await slack.getResponseTo(`slacklog ${requestURL}`);
 
 		const expectURL: string = '<https://slack-log.tsg.ne.jp/C0123ABCD/1501234567.890123>';
 		expect(channel).toBe(slack.fakeChannel);
@@ -42,7 +41,7 @@ describe('slacklog', () => {
 
 	it('respond to slacklog-ize request of practical url from default web UI', async () => {
 		const requestURL: string = '<https://tsg-ut.slack.com/archives/C7AAX50QY/p1603287289337400?thread_ts=1603267719.496100&amp;cid=C7AAX50QY>';
-		const {channel, text}: {channel: string, text: string} = await slack.getResponseTo(`slacklog ${requestURL}`);
+		const {channel, text} = await slack.getResponseTo(`slacklog ${requestURL}`);
 
 		const expectURL: string = '<https://slack-log.tsg.ne.jp/C7AAX50QY/1603287289.337400>';
 		expect(channel).toBe(slack.fakeChannel);
@@ -51,7 +50,7 @@ describe('slacklog', () => {
 
 	it('respond to slacklog-ize request of practical url from iOS app', async () => {
 		const requestURL: string = '<https://tsg-ut.slack.com/archives/C7AAX50QY/p1603288141348600?thread_ts=1603287978.345500&channel=C7AAX50QY&message_ts=1603288141.348600>';
-		const {channel, text}: {channel: string, text: string} = await slack.getResponseTo(`slacklog ${requestURL}`);
+		const {channel, text} = await slack.getResponseTo(`slacklog ${requestURL}`);
 
 		const expectURL: string = '<https://slack-log.tsg.ne.jp/C7AAX50QY/1603288141.348600>';
 		expect(channel).toBe(slack.fakeChannel);

--- a/sunrise/index.test.ts
+++ b/sunrise/index.test.ts
@@ -11,8 +11,7 @@ jest.mock('../lib/state');
 
 import FakeTimers from '@sinonjs/fake-timers';
 import type {InstalledClock} from '@sinonjs/fake-timers';
-// @ts-expect-error: Untyped
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 import sunrise from './index';
 
 let slack: Slack = null;

--- a/sushi-bot/index.test.js
+++ b/sushi-bot/index.test.js
@@ -11,7 +11,7 @@ jest.mock('fs-extra', () => ({
 
 const moment = require('moment');
 const {default: sushi} = require('./index.ts');
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 
 let slack = null;
 

--- a/tahoiya/index.test.js
+++ b/tahoiya/index.test.js
@@ -8,7 +8,7 @@ const download = require('download');
 
 download.response = Array(10).fill('単語\tたんご\t単語\t000').join('\n');
 
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 const tahoiya = require('./index.js');
 
 let slack = null;

--- a/taimai/index.ts
+++ b/taimai/index.ts
@@ -3,7 +3,7 @@ import type { ChatPostMessageArguments, ChatUpdateArguments, WebClient } from '@
 import { Mutex } from 'async-mutex';
 import { increment } from '../achievements';
 import type { SlackInterface } from '../lib/slack';
-import { TeamEventClientInterface } from '../lib/slackEventClient';
+import type { EventEmitter } from 'events';
 import State from '../lib/state';
 import config from './config';
 import announceGameEnd from './views/announceGameEnd';
@@ -45,7 +45,7 @@ const mutex = new Mutex();
 
 class Taimai {
 	webClient: WebClient;
-	eventClient: TeamEventClientInterface;
+	eventClient: EventEmitter;
 	messageClient: ReturnType<typeof createMessageAdapter>;
 
 	state: TaimaiState;
@@ -56,7 +56,7 @@ class Taimai {
 		messageClient,
 	}: {
 		webClient: WebClient,
-		eventClient: TeamEventClientInterface,
+		eventClient: EventEmitter,
 		messageClient: ReturnType<typeof createMessageAdapter>,
 	}) {
 		this.webClient = webClient;

--- a/taimai/index.ts
+++ b/taimai/index.ts
@@ -3,7 +3,7 @@ import type { ChatPostMessageArguments, ChatUpdateArguments, WebClient } from '@
 import { Mutex } from 'async-mutex';
 import { increment } from '../achievements';
 import type { SlackInterface } from '../lib/slack';
-import { TeamEventClient } from '../lib/slackEventClient';
+import { TeamEventClientInterface } from '../lib/slackEventClient';
 import State from '../lib/state';
 import config from './config';
 import announceGameEnd from './views/announceGameEnd';
@@ -45,7 +45,7 @@ const mutex = new Mutex();
 
 class Taimai {
 	webClient: WebClient;
-	eventClient: TeamEventClient;
+	eventClient: TeamEventClientInterface;
 	messageClient: ReturnType<typeof createMessageAdapter>;
 
 	state: TaimaiState;
@@ -56,7 +56,7 @@ class Taimai {
 		messageClient,
 	}: {
 		webClient: WebClient,
-		eventClient: TeamEventClient,
+		eventClient: TeamEventClientInterface,
 		messageClient: ReturnType<typeof createMessageAdapter>,
 	}) {
 		this.webClient = webClient;

--- a/tiobot/index.test.ts
+++ b/tiobot/index.test.ts
@@ -1,6 +1,5 @@
+import Slack from '../lib/slackMock';
 import cubebot from './index';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
 
 let slack: Slack = null;
 
@@ -13,7 +12,7 @@ beforeEach(() => {
 describe('tiobot', () => {
 	it('responds to tio.run URL', async () => {
 		const {text, username} = await slack.getResponseTo(
-			'https://tio.run/##y0osSyxOLsosKNHNy09J/f8/OT@vOD8nVS8nP11DySM1JydfRyE8vygnRVFJ0/r/fwA'
+			'https://tio.run/##y0osSyxOLsosKNHNy09J/f8/OT@vOD8nVS8nP11DySM1JydfRyE8vygnRVFJ0/r/fwA',
 		);
 
 		expect(username).toBe('tiobot');

--- a/vocabwar/index.test.js
+++ b/vocabwar/index.test.js
@@ -7,7 +7,7 @@ jest.mock('word2vec');
 jest.mock('./state.json', () => ({}), {virtual: true});
 
 const vocabwar = require('./index.js');
-const Slack = require('../lib/slackMock.js');
+const {default: Slack} = require('../lib/slackMock.ts');
 const {promisify} = require('util');
 const path = require('path');
 const fs = require('fs');

--- a/voiperrobot/index.test.ts
+++ b/voiperrobot/index.test.ts
@@ -1,8 +1,7 @@
 jest.mock('../achievements');
 
 import voiperrobot from './index';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 
 let slack: Slack = null;
 

--- a/wadokaichin/index.test.ts
+++ b/wadokaichin/index.test.ts
@@ -1,5 +1,4 @@
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 import path from 'path';
 
 jest.mock('fs');

--- a/welcome/index.test.ts
+++ b/welcome/index.test.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 
-// @ts-expect-error
 import Slack from '../lib/slackMock';
 
 import welcome from './index';

--- a/wordle-battle/index.test.ts
+++ b/wordle-battle/index.test.ts
@@ -1,6 +1,5 @@
 import wordle_battle from './index';
-// @ts-expect-error
-import Slack from '../lib/slackMock.js';
+import Slack from '../lib/slackMock';
 
 let slack: Slack = null;
 
@@ -12,28 +11,28 @@ beforeEach(async () => {
 
 describe('wordle battle', () => {
     it('respond to wordle battle', async () => {
-        const { channel, text }: { channel: string, text: string } = await slack.getResponseTo('wordle battle');
+        const { channel, text } = await slack.getResponseTo('wordle battle');
 
         expect(channel).toBe(slack.fakeChannel);
         expect(text).toContain('Wordle Battle を開始します！');
     });
     
     it('respond to wordle battle 10', async () => {
-        const { channel, text }: { channel: string, text: string } = await slack.getResponseTo('wordle battle 10');
+        const { channel, text } = await slack.getResponseTo('wordle battle 10');
 
         expect(channel).toBe(slack.fakeChannel);
         expect(text).toContain('Wordle Battle を開始します！');
     });
     
     it('respond to wordle battle 100', async () => {
-        const { channel, text }: { channel: string, text: string } = await slack.getResponseTo('wordle battle 100');
+        const { channel, text } = await slack.getResponseTo('wordle battle 100');
 
         expect(channel).toBe(slack.fakeChannel);
         expect(text).toContain('単語のみに対応しています。');
     });
 
     it('respond to wordle reset', async () => {
-        const { channel, text }: { channel: string, text: string } = await slack.getResponseTo('wordle reset');
+        const { channel, text } = await slack.getResponseTo('wordle reset');
 
         expect(channel).toBe(slack.fakeChannel);
         expect(text).toContain('Wordle Battle をリセットしました。');


### PR DESCRIPTION
Ref: #181

* lib/slackMockをTypeScriptに変換
* それに伴いTeamEventClientを使用している箇所の型注釈をEventEmitterに変換 (型が強くなっている (?) のでヨシ!)
* room-gatchaのテストが破滅したので大幅に書き直し

将来的にはSlackMock.webClientもProxyじゃなくてちゃんと全部jest.fn()でモックするようにしたい