### PR TITLE
character-quiz: & を含む項目の正解にフルネームが含まれていなかったのを修正

### DIFF
--- a/character-quiz/index.ts
+++ b/character-quiz/index.ts
@@ -86,7 +86,7 @@ const loadCharacters = async (author: string) => {
 			}  
 
 			const names = [...characterNames, ...characterRubys];
-			const namePartsList = names.map((name) => name.split(/[&\s]/));
+			const namePartsList = names.map((name) => name.split('&').map((nameOne) => nameOne.split(' ')));
 
 			const normalizedWorkName = workName.startsWith('"')
 				? workName.slice(1, -1)
@@ -100,12 +100,13 @@ const loadCharacters = async (author: string) => {
 					characterName: characterNames[0].replace(/ /g, ''),
 					workName: normalizedWorkName,
 					validAnswers: [
-						...namePartsList.map((parts) => parts.join('')),
-						...namePartsList.flat(),
+						...namePartsList.map((name) => name.flat().join('')),
+						...namePartsList.map((name) => name.map((nameOne) => nameOne.join(''))).flat(),
+						...namePartsList.flat().flat(),
 					],
 					author,
 					rating: rating ?? '0',
-					characterId: `${namePartsList[0].join('')}\0${normalizedWorkName}`,
+					characterId: `${namePartsList[0].flat().join('')}\0${normalizedWorkName}`,
 				} as CharacterData
 			];
 		})


### PR DESCRIPTION
「名字A 名前A&名字B 名前B」という項目に対して、「名字A名前A」が正解リストに含まれていなかった