### PR TITLE
context-free-botの投稿頻度を10分の1に変更

### DIFF
--- a/context-free/index.ts
+++ b/context-free/index.ts
@@ -146,7 +146,7 @@ const composePost = async (message: string): Promise<string> => {
 };
 
 const randomInterval = () =>
-  1000 * 60 * (90 + (Math.random() - 0.5) * 2 * 60);
+  1000 * 60 * (60 * 15 + (Math.random() - 0.5) * 2 * 60);
 
 export const server = ({eventClient, webClient: slack}: SlackInterface) => plugin(async (fastify) => {
   const postWord = async () => {


### PR DESCRIPTION
Resolves #886.

#886 での投票結果、context-free-botの頻度を減らすことになりました。このプルリクはその実装になります。