### PR TITLE
Discord通知を#_discordにも流すように修正 & sandboxに対する1つ前の通知を削除するよう修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ CHANNEL_SIG_DREAM=CXXXXXXXX
 CHANNEL_PRLOG=CXXXXXXXX
 CHANNEL_QUIZ=CXXXXXXXX
 CHANNEL_SELF_INTRODUCTION=CXXXXXXXX
+CHANNEL_DISCORD=CXXXXXXXX
 
 # SlackのチームID。Events API で飛んできたリクエストを適切にフィルタリングするために必要。
 # 下の値は TSG Slack のチームIDが設定されている。自分用Slackワークスペースで動かす時以外は特に変更する必要はない。

--- a/discord/hayaoshiUtils.test.ts
+++ b/discord/hayaoshiUtils.test.ts
@@ -81,12 +81,14 @@ const testCases: [string, string, string[]][] = [
 	],
 ];
 
-describe('extractValidAnswers', () => {
-	for (const [question, answer, expected] of testCases) {
-		it(`converts ${inspect(answer)} to ${inspect(expected)}`, () => {
-			const sortedResult = extractValidAnswers(question, answer).slice().sort();
-			const sortedExpected = expected.slice().sort();
-			expect(sortedResult).toStrictEqual(sortedExpected);
-		});
-	}
+describe('discord', () => {
+	describe('extractValidAnswers', () => {
+		for (const [question, answer, expected] of testCases) {
+			it(`converts ${inspect(answer)} to ${inspect(expected)}`, () => {
+				const sortedResult = extractValidAnswers(question, answer).slice().sort();
+				const sortedExpected = expected.slice().sort();
+				expect(sortedResult).toStrictEqual(sortedExpected);
+			});
+		}
+	});
 });

--- a/discord/index.ts
+++ b/discord/index.ts
@@ -1,20 +1,15 @@
-import {VoiceConnectionStatus, joinVoiceChannel} from '@discordjs/voice';
+import {joinVoiceChannel} from '@discordjs/voice';
 import type {DiscordGatewayAdapterCreator} from '@discordjs/voice';
-import type {ContextBlock, WebAPICallResult} from '@slack/web-api';
-import {Mutex} from 'async-mutex';
-import Discord, {TextChannel, Collection, Snowflake, GuildMember, VoiceChannel, GatewayIntentBits} from 'discord.js';
+import Discord, {TextChannel, VoiceChannel, GatewayIntentBits} from 'discord.js';
 import logger from '../lib/logger';
 import type {SlackInterface} from '../lib/slack';
 import {getMemberIcon, getMemberName} from '../lib/slackUtils';
 import State from '../lib/state';
 import Hayaoshi from './hayaoshi';
+import {Notifier} from './notifier';
 import TTS from './tts';
 
 const log = logger.child({bot: 'discord'});
-
-interface ChatPostMessageResult extends WebAPICallResult {
-	ts: string;
-}
 
 interface StateObj {
 	users: {discord: string, slack: string}[],
@@ -33,38 +28,13 @@ const discord = new Discord.Client({
 
 discord.login(process.env.TSGBOT_DISCORD_TOKEN);
 
-const mutex = new Mutex();
-
-const getMembersBlock = (roomName: string, members: Collection<Snowflake, GuildMember>) => (
-	{
-		type: 'context',
-		elements: [
-			{
-				type: 'mrkdwn',
-				text: `*[${roomName}]*`,
-			},
-			...Array.from(members.values()).slice(0, 8)
-				.map((member) => (
-					{
-						type: 'image',
-						image_url: member.user.displayAvatarURL({extension: 'png', size: 64}),
-						alt_text: member.displayName,
-					}
-				)),
-			{
-				type: 'plain_text',
-				emoji: true,
-				text: `${members.size} users`,
-			},
-		],
-	} as ContextBlock
-);
-
 export default async ({webClient: slack, eventClient}: SlackInterface) => {
 	const state = await State.init<StateObj>('discord', {
 		users: [],
 		ttsDictionary: [{key: 'https?:\\S*', value: 'URL省略'}],
 	});
+
+	const notifier = new Notifier(slack);
 
 	const joinVoiceChannelFn = (channelId: string = process.env.DISCORD_SANDBOX_VOICE_CHANNEL_ID) => {
 		const channel = discord.channels.cache.get(channelId) as VoiceChannel;
@@ -75,20 +45,6 @@ export default async ({webClient: slack, eventClient}: SlackInterface) => {
 			adapterCreator: channel.guild.voiceAdapterCreator as unknown as DiscordGatewayAdapterCreator,
 		});
 		return connection;
-	};
-	const roomNotifyCache = {
-		lastUnixTime: 0, usernames: <string[]>[], ts: '', action: '',
-	};
-	const notifyCacheLimit = 60000; // 1min
-	const usernameSummarizer = (usernames: string[]) => {
-		if (usernames.length >= 3) {
-			return `＊${usernames[0]}＊, ＊${usernames[1]}＊, ほか${usernames.length - 2}名`;
-		} else if (usernames.length === 2) {
-			return `＊${usernames[0]}＊, ＊${usernames[1]}＊`;
-		} else if (usernames.length === 1) {
-			return `＊${usernames[0]}＊`;
-		}
-		return '';
 	};
 
 	let hayaoshi = new Hayaoshi(joinVoiceChannelFn, state.users);
@@ -131,159 +87,8 @@ export default async ({webClient: slack, eventClient}: SlackInterface) => {
 		tts.onMessage(message);
 	});
 
-	const postMessage = async (
-		{text, count, rooms, ts}: {
-			text: string,
-			count: number,
-			rooms: {
-				name: string,
-				members: Discord.Collection<string, Discord.GuildMember>,
-			}[],
-			ts: string,
-		},
-	) => {
-		const countText = count === null ? '' : `現在のアクティブ人数 ${count}人`;
-
-		if (ts) {
-			const result = await slack.chat.update({
-				ts,
-				channel: process.env.CHANNEL_SANDBOX,
-				username: 'Discord',
-				icon_emoji: ':discord:',
-				text: `${text}\n${countText}`,
-				blocks: [
-					{
-						type: 'section',
-						text: {
-							type: 'mrkdwn',
-							text,
-						},
-					},
-					...rooms.map((room) => getMembersBlock(room.name, room.members)),
-				],
-			}) as ChatPostMessageResult;
-			return result;
-		}
-
-		const response = await slack.chat.postMessage({
-			channel: process.env.CHANNEL_SANDBOX,
-			username: 'Discord',
-			icon_emoji: ':discord:',
-			text: `${text}\n${countText}`,
-			blocks: [
-				{
-					type: 'section',
-					text: {
-						type: 'mrkdwn',
-						text,
-					},
-				},
-				...rooms.map((room) => getMembersBlock(room.name, room.members)),
-			],
-		}) as ChatPostMessageResult;
-		return response;
-	};
-
 	discord.on('voiceStateUpdate', (oldState, newState) => {
-		if (oldState.member.user.bot) {
-			return;
-		}
-
-		const username = oldState.member.displayName;
-		const eventTime = Date.now();
-
-		mutex.runExclusive(async () => {
-			// leave
-			if (oldState.channel !== null && newState.channel === null) {
-				const roomName = oldState.channel.name;
-				const roomId = oldState.channel.id;
-				const count = oldState.channel.members.size;
-				const actionName = `leave-${roomId}`;
-				const update = roomNotifyCache.lastUnixTime + notifyCacheLimit > eventTime && roomNotifyCache.action === actionName;
-
-				if (update) {
-					roomNotifyCache.usernames.push(username);
-				} else {
-					roomNotifyCache.usernames = [username];
-				}
-
-				const response = await postMessage({
-					text: `${usernameSummarizer(roomNotifyCache.usernames)}が<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${roomId}|${roomName}>からログアウトしました`,
-					count,
-					rooms: [{name: roomName, members: oldState.channel.members}],
-					ts: update ? roomNotifyCache.ts : null,
-				});
-
-				if (!update && response.ok) {
-					roomNotifyCache.ts = response.ts;
-				}
-
-				roomNotifyCache.action = actionName;
-				roomNotifyCache.lastUnixTime = eventTime;
-			}
-
-			// join
-			if (newState.channel !== null && oldState.channel === null) {
-				const roomName = newState.channel.name;
-				const roomId = newState.channel.id;
-				const count = newState.channel.members.size;
-				const actionName = `join-${roomId}`;
-				const update = roomNotifyCache.lastUnixTime + notifyCacheLimit > eventTime && roomNotifyCache.action === actionName;
-
-				if (update) {
-					roomNotifyCache.usernames.push(username);
-				} else {
-					roomNotifyCache.usernames = [username];
-				}
-
-				const response = await postMessage({
-					text: `${usernameSummarizer(roomNotifyCache.usernames)}が<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${roomId}|${roomName}>にログインしました`,
-					count,
-					rooms: [{name: roomName, members: newState.channel.members}],
-					ts: update ? roomNotifyCache.ts : null,
-				});
-
-				if (!update && response.ok) {
-					roomNotifyCache.ts = response.ts;
-				}
-
-				roomNotifyCache.action = actionName;
-				roomNotifyCache.lastUnixTime = eventTime;
-			}
-
-			// move
-			if (oldState.channel !== null && newState.channel !== null && oldState.channel.id !== newState.channel.id) {
-				const newRoomName = newState.channel.name;
-				const newRoomId = newState.channel.id;
-				const oldRoomName = oldState.channel.name;
-				const oldRoomId = oldState.channel.id;
-				const actionName = `join-${oldRoomId}-${newRoomId}`;
-				const update = roomNotifyCache.lastUnixTime + notifyCacheLimit > eventTime && roomNotifyCache.action === actionName;
-
-				if (update) {
-					roomNotifyCache.usernames.push(username);
-				} else {
-					roomNotifyCache.usernames = [username];
-				}
-
-				const response = await postMessage({
-					text: `${usernameSummarizer(roomNotifyCache.usernames)}が<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${oldRoomId}|${oldRoomName}>から<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${newRoomId}|${newRoomName}>に移動しました`,
-					count: null,
-					rooms: [
-						{name: oldRoomName, members: oldState.channel.members},
-						{name: newRoomName, members: newState.channel.members},
-					],
-					ts: update ? roomNotifyCache.ts : null,
-				});
-
-				if (!update && response.ok) {
-					roomNotifyCache.ts = response.ts;
-				}
-
-				roomNotifyCache.action = actionName;
-				roomNotifyCache.lastUnixTime = eventTime;
-			}
-		});
+		notifier.voiceStateUpdate(oldState, newState);
 	});
 
 	eventClient.on('message', async (message) => {

--- a/discord/index.ts
+++ b/discord/index.ts
@@ -34,7 +34,7 @@ export default async ({webClient: slack, eventClient}: SlackInterface) => {
 		ttsDictionary: [{key: 'https?:\\S*', value: 'URL省略'}],
 	});
 
-	const notifier = new Notifier(slack);
+	const slackNotifier = new Notifier(slack);
 
 	const joinVoiceChannelFn = (channelId: string = process.env.DISCORD_SANDBOX_VOICE_CHANNEL_ID) => {
 		const channel = discord.channels.cache.get(channelId) as VoiceChannel;
@@ -88,7 +88,7 @@ export default async ({webClient: slack, eventClient}: SlackInterface) => {
 	});
 
 	discord.on('voiceStateUpdate', (oldState, newState) => {
-		notifier.voiceStateUpdate(oldState, newState);
+		slackNotifier.voiceStateUpdate(oldState, newState);
 	});
 
 	eventClient.on('message', async (message) => {

--- a/discord/notifier.test.ts
+++ b/discord/notifier.test.ts
@@ -27,6 +27,15 @@ describe('discord', () => {
 			displayName: 'test-user',
 		} as GuildMember;
 
+		const BOT_MEMBER = {
+			user: {
+				id: '0987654321',
+				displayAvatarURL: () => 'https://example.com/avatar.png',
+				bot: true,
+			} as User,
+			displayName: 'bot-user',
+		} as GuildMember;
+
 		const TEST_CHANNEL = {
 			id: '0123456789',
 			name: 'test-channel',
@@ -40,28 +49,36 @@ describe('discord', () => {
 			member: TEST_MEMBER,
 		} as VoiceState;
 
-		const TEST_CHANNEL_STATE = {
+		const JOINED_CHANNEL_STATE = {
 			channel: TEST_CHANNEL,
 			member: TEST_MEMBER,
 		} as VoiceState;
 
-		it('should record latest message timestamp of each channel', async () => {
+		const EMPTY_BOT_CHANNEL_STATE = {
+			channel: null,
+			member: BOT_MEMBER,
+		} as VoiceState;
+
+		const JOINED_BOT_CHANNEL_STATE = {
+			channel: TEST_CHANNEL,
+			member: BOT_MEMBER,
+		} as VoiceState;
+
+		it('should handle voice state update of joining and notify channels', async () => {
 			process.env.CHANNEL_SANDBOX = FAKE_SANDBOX;
 			process.env.CHANNEL_DISCORD = FAKE_DISCORD;
 
 			const slack = new Slack();
 
 			const postMessage = slack.webClient.chat.postMessage as jest.MockedFunction<typeof slack.webClient.chat.postMessage>;
-			postMessage.mockResolvedValueOnce({
+			postMessage.mockResolvedValue({
 				ok: true,
-				message: {
-					ts: '123456789.123456',
-				},
+				ts: '123456789.123456',
 			});
 
 			const notifier = new Notifier(slack.webClient);
 
-			await notifier.voiceStateUpdate(EMPTY_CHANNEL_STATE, TEST_CHANNEL_STATE);
+			await notifier.voiceStateUpdate(EMPTY_CHANNEL_STATE, JOINED_CHANNEL_STATE);
 
 			const expectedContent = {
 				blocks: [
@@ -106,6 +123,119 @@ describe('discord', () => {
 				channel: FAKE_DISCORD,
 				...expectedContent,
 			});
+		});
+
+		it('should handle voice state update of leaving and notify channels', async () => {
+			process.env.CHANNEL_SANDBOX = FAKE_SANDBOX;
+			process.env.CHANNEL_DISCORD = FAKE_DISCORD;
+
+			const slack = new Slack();
+
+			const postMessage = slack.webClient.chat.postMessage as jest.MockedFunction<typeof slack.webClient.chat.postMessage>;
+			postMessage.mockResolvedValue({
+				ok: true,
+				ts: '123456789.123456',
+			});
+
+			const notifier = new Notifier(slack.webClient);
+
+			await notifier.voiceStateUpdate(JOINED_CHANNEL_STATE, EMPTY_CHANNEL_STATE);
+
+			const expectedContent = {
+				blocks: [
+					{
+						text: {
+							text: '＊test-user＊がtest-channelからログアウトしました',
+							type: 'mrkdwn',
+						},
+						type: 'section',
+					},
+					{
+						elements: [
+							{
+								text: '*[test-channel]*',
+								type: 'mrkdwn',
+							},
+							{
+								alt_text: 'test-user',
+								image_url: 'https://example.com/avatar.png',
+								type: 'image',
+							},
+							{
+								emoji: true,
+								text: '1 users',
+								type: 'plain_text',
+							},
+						],
+						type: 'context',
+					},
+				],
+				icon_emoji: ':discord:',
+				text: '＊test-user＊がtest-channelからログアウトしました\n現在のアクティブ人数 1人',
+				username: 'Discord',
+			};
+
+			expect(slack.webClient.chat.postMessage).toBeCalledWith({
+				channel: FAKE_SANDBOX,
+				...expectedContent,
+			});
+
+			expect(slack.webClient.chat.postMessage).toBeCalledWith({
+				channel: FAKE_DISCORD,
+				...expectedContent,
+			});
+		});
+
+		it('should not notify when member is bot', async () => {
+			process.env.CHANNEL_SANDBOX = FAKE_SANDBOX;
+			process.env.CHANNEL_DISCORD = FAKE_DISCORD;
+
+			const slack = new Slack();
+
+			const postMessage = slack.webClient.chat.postMessage as jest.MockedFunction<typeof slack.webClient.chat.postMessage>;
+			postMessage.mockResolvedValue({ok: false});
+
+			const notifier = new Notifier(slack.webClient);
+
+			await notifier.voiceStateUpdate(EMPTY_BOT_CHANNEL_STATE, JOINED_BOT_CHANNEL_STATE);
+
+			expect(slack.webClient.chat.postMessage).not.toBeCalled();
+		});
+
+		it('should erase message when next message is sent', async () => {
+			process.env.CHANNEL_SANDBOX = FAKE_SANDBOX;
+			process.env.CHANNEL_DISCORD = FAKE_DISCORD;
+
+			const slack = new Slack();
+
+			const postMessage = slack.webClient.chat.postMessage as jest.MockedFunction<typeof slack.webClient.chat.postMessage>;
+			postMessage.mockImplementation(async (message) => {
+				if (message.channel === FAKE_SANDBOX) {
+					return {
+						ok: true,
+						ts: '123456789.123456',
+					};
+				}
+				return {
+					ok: true,
+					ts: '987654321.123456',
+				};
+			});
+
+			const notifier = new Notifier(slack.webClient);
+
+			await notifier.voiceStateUpdate(EMPTY_CHANNEL_STATE, JOINED_CHANNEL_STATE);
+
+			const deleteMessage = slack.webClient.chat.delete as jest.MockedFunction<typeof slack.webClient.chat.delete>;
+			deleteMessage.mockResolvedValue({ok: true});
+
+			await notifier.voiceStateUpdate(JOINED_CHANNEL_STATE, EMPTY_CHANNEL_STATE);
+
+			expect(slack.webClient.chat.delete).toBeCalledTimes(1);
+			expect(slack.webClient.chat.delete).toBeCalledWith({
+				channel: FAKE_SANDBOX,
+				ts: '123456789.123456',
+			})
 		});
 	});
 });

--- a/discord/notifier.test.ts
+++ b/discord/notifier.test.ts
@@ -1,0 +1,111 @@
+/* eslint-disable import/imports-first */
+/* eslint-disable import/first */
+/* eslint-env jest */
+
+jest.mock('../lib/state');
+jest.mock('../lib/slack');
+jest.mock('../lib/slackUtils');
+jest.mock('node-schedule', () => ({
+	scheduleJob: jest.fn(),
+}));
+
+import {GuildMember, User, VoiceChannel, VoiceState} from 'discord.js';
+import Slack from '../lib/slackMock';
+import {Notifier} from './notifier';
+
+describe('discord', () => {
+	describe('Notifier', () => {
+		const FAKE_SANDBOX = 'C12345678';
+		const FAKE_DISCORD = 'C87654321';
+
+		const TEST_MEMBER = {
+			user: {
+				id: '1234567890',
+				displayAvatarURL: () => 'https://example.com/avatar.png',
+				bot: false,
+			} as User,
+			displayName: 'test-user',
+		} as GuildMember;
+
+		const TEST_CHANNEL = {
+			id: '0123456789',
+			name: 'test-channel',
+			members: new Map([
+				['1234567890', TEST_MEMBER],
+			]),
+		} as VoiceChannel;
+
+		const EMPTY_CHANNEL_STATE = {
+			channel: null,
+			member: TEST_MEMBER,
+		} as VoiceState;
+
+		const TEST_CHANNEL_STATE = {
+			channel: TEST_CHANNEL,
+			member: TEST_MEMBER,
+		} as VoiceState;
+
+		it('should record latest message timestamp of each channel', async () => {
+			process.env.CHANNEL_SANDBOX = FAKE_SANDBOX;
+			process.env.CHANNEL_DISCORD = FAKE_DISCORD;
+
+			const slack = new Slack();
+
+			const postMessage = slack.webClient.chat.postMessage as jest.MockedFunction<typeof slack.webClient.chat.postMessage>;
+			postMessage.mockResolvedValueOnce({
+				ok: true,
+				message: {
+					ts: '123456789.123456',
+				},
+			});
+
+			const notifier = new Notifier(slack.webClient);
+
+			await notifier.voiceStateUpdate(EMPTY_CHANNEL_STATE, TEST_CHANNEL_STATE);
+
+			const expectedContent = {
+				blocks: [
+					{
+						text: {
+							text: '＊test-user＊がtest-channelにログインしました',
+							type: 'mrkdwn',
+						},
+						type: 'section',
+					},
+					{
+						elements: [
+							{
+								text: '*[test-channel]*',
+								type: 'mrkdwn',
+							},
+							{
+								alt_text: 'test-user',
+								image_url: 'https://example.com/avatar.png',
+								type: 'image',
+							},
+							{
+								emoji: true,
+								text: '1 users',
+								type: 'plain_text',
+							},
+						],
+						type: 'context',
+					},
+				],
+				icon_emoji: ':discord:',
+				text: '＊test-user＊がtest-channelにログインしました\n現在のアクティブ人数 1人',
+				username: 'Discord',
+			};
+
+			expect(slack.webClient.chat.postMessage).toBeCalledWith({
+				channel: FAKE_SANDBOX,
+				...expectedContent,
+			});
+
+			expect(slack.webClient.chat.postMessage).toBeCalledWith({
+				channel: FAKE_DISCORD,
+				...expectedContent,
+			});
+		});
+	});
+});

--- a/discord/notifier.ts
+++ b/discord/notifier.ts
@@ -1,0 +1,214 @@
+import type {ContextBlock, WebClient} from '@slack/web-api';
+import {Mutex} from 'async-mutex';
+import type {Collection, GuildMember, Snowflake, VoiceState} from 'discord.js';
+
+const mutex = new Mutex();
+
+export class Notifier {
+	slack: WebClient;
+
+	lastNotificationTimestamp: string | null = null;
+
+	roomNotifyCache = {
+		lastUnixTime: 0, usernames: <string[]>[], ts: '', action: '',
+	};
+
+	notifyCacheLimit = 60000; // 1min
+
+	constructor(slack: WebClient) {
+		this.slack = slack;
+	}
+
+	usernameSummarizer(usernames: string[]) {
+		if (usernames.length >= 3) {
+			return `＊${usernames[0]}＊, ＊${usernames[1]}＊, ほか${usernames.length - 2}名`;
+		} else if (usernames.length === 2) {
+			return `＊${usernames[0]}＊, ＊${usernames[1]}＊`;
+		} else if (usernames.length === 1) {
+			return `＊${usernames[0]}＊`;
+		}
+		return '';
+	}
+
+	getMembersBlock(roomName: string, members: Collection<Snowflake, GuildMember>) {
+		return (
+			{
+				type: 'context',
+				elements: [
+					{
+						type: 'mrkdwn',
+						text: `*[${roomName}]*`,
+					},
+					...Array.from(members.values()).slice(0, 8)
+						.map((member) => (
+							{
+								type: 'image',
+								image_url: member.user.displayAvatarURL({extension: 'png', size: 64}),
+								alt_text: member.displayName,
+							}
+						)),
+					{
+						type: 'plain_text',
+						emoji: true,
+						text: `${members.size} users`,
+					},
+				],
+			} as ContextBlock
+		);
+	}
+
+	async postMessage(
+		{text, count, rooms, ts}: {
+			text: string,
+			count: number,
+			rooms: {
+				name: string,
+				members: Collection<string, GuildMember>,
+			}[],
+			ts: string,
+		},
+	) {
+		const countText = count === null ? '' : `現在のアクティブ人数 ${count}人`;
+
+		if (ts) {
+			const result = await this.slack.chat.update({
+				ts,
+				channel: process.env.CHANNEL_SANDBOX,
+				username: 'Discord',
+				icon_emoji: ':discord:',
+				text: `${text}\n${countText}`,
+				blocks: [
+					{
+						type: 'section',
+						text: {
+							type: 'mrkdwn',
+							text,
+						},
+					},
+					...rooms.map((room) => this.getMembersBlock(room.name, room.members)),
+				],
+			});
+			return result;
+		}
+
+		const response = await this.slack.chat.postMessage({
+			channel: process.env.CHANNEL_SANDBOX,
+			username: 'Discord',
+			icon_emoji: ':discord:',
+			text: `${text}\n${countText}`,
+			blocks: [
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text,
+					},
+				},
+				...rooms.map((room) => this.getMembersBlock(room.name, room.members)),
+			],
+		});
+		return response;
+	}
+
+	async voiceStateUpdate(oldState: VoiceState, newState: VoiceState) {
+		if (oldState.member.user.bot) {
+			return;
+		}
+
+		const username = oldState.member.displayName;
+		const eventTime = Date.now();
+
+		await mutex.runExclusive(async () => {
+			// leave
+			if (oldState.channel !== null && newState.channel === null) {
+				const roomName = oldState.channel.name;
+				const roomId = oldState.channel.id;
+				const count = oldState.channel.members.size;
+				const actionName = `leave-${roomId}`;
+				const update = this.roomNotifyCache.lastUnixTime + this.notifyCacheLimit > eventTime && this.roomNotifyCache.action === actionName;
+
+				if (update) {
+					this.roomNotifyCache.usernames.push(username);
+				} else {
+					this.roomNotifyCache.usernames = [username];
+				}
+
+				const response = await this.postMessage({
+					text: `${this.usernameSummarizer(this.roomNotifyCache.usernames)}が<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${roomId}|${roomName}>からログアウトしました`,
+					count,
+					rooms: [{name: roomName, members: oldState.channel.members}],
+					ts: update ? this.roomNotifyCache.ts : null,
+				});
+
+				if (!update && response.ok) {
+					this.roomNotifyCache.ts = response.ts;
+				}
+
+				this.roomNotifyCache.action = actionName;
+				this.roomNotifyCache.lastUnixTime = eventTime;
+			}
+
+			// join
+			if (newState.channel !== null && oldState.channel === null) {
+				const roomName = newState.channel.name;
+				const roomId = newState.channel.id;
+				const count = newState.channel.members.size;
+				const actionName = `join-${roomId}`;
+				const update = this.roomNotifyCache.lastUnixTime + this.notifyCacheLimit > eventTime && this.roomNotifyCache.action === actionName;
+
+				if (update) {
+					this.roomNotifyCache.usernames.push(username);
+				} else {
+					this.roomNotifyCache.usernames = [username];
+				}
+
+				const response = await this.postMessage({
+					text: `${this.usernameSummarizer(this.roomNotifyCache.usernames)}が<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${roomId}|${roomName}>にログインしました`,
+					count,
+					rooms: [{name: roomName, members: newState.channel.members}],
+					ts: update ? this.roomNotifyCache.ts : null,
+				});
+
+				if (!update && response.ok) {
+					this.roomNotifyCache.ts = response.ts;
+				}
+
+				this.roomNotifyCache.action = actionName;
+				this.roomNotifyCache.lastUnixTime = eventTime;
+			}
+
+			// move
+			if (oldState.channel !== null && newState.channel !== null && oldState.channel.id !== newState.channel.id) {
+				const newRoomName = newState.channel.name;
+				const newRoomId = newState.channel.id;
+				const oldRoomName = oldState.channel.name;
+				const oldRoomId = oldState.channel.id;
+				const actionName = `join-${oldRoomId}-${newRoomId}`;
+				const update = this.roomNotifyCache.lastUnixTime + this.notifyCacheLimit > eventTime && this.roomNotifyCache.action === actionName;
+
+				if (update) {
+					this.roomNotifyCache.usernames.push(username);
+				} else {
+					this.roomNotifyCache.usernames = [username];
+				}
+
+				const response = await this.postMessage({
+					text: `${this.usernameSummarizer(this.roomNotifyCache.usernames)}が<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${oldRoomId}|${oldRoomName}>から<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${newRoomId}|${newRoomName}>に移動しました`,
+					count: null,
+					rooms: [
+						{name: oldRoomName, members: oldState.channel.members},
+						{name: newRoomName, members: newState.channel.members},
+					],
+					ts: update ? this.roomNotifyCache.ts : null,
+				});
+
+				if (!update && response.ok) {
+					this.roomNotifyCache.ts = response.ts;
+				}
+
+				this.roomNotifyCache.action = actionName;
+				this.roomNotifyCache.lastUnixTime = eventTime;
+			}
+		});
+	}
+}

--- a/discord/notifier.ts
+++ b/discord/notifier.ts
@@ -5,15 +5,15 @@ import type {Collection, GuildMember, Snowflake, VoiceState} from 'discord.js';
 const mutex = new Mutex();
 
 export class Notifier {
-	slack: WebClient;
+	private slack: WebClient;
 
-	channelNotificationTimestamps: Map<string, string> = new Map();
+	private channelNotificationTimestamps: Map<string, string> = new Map();
 
 	constructor(slack: WebClient) {
 		this.slack = slack;
 	}
 
-	getMembersBlock(roomName: string, members: Collection<Snowflake, GuildMember>) {
+	private getMembersBlock(roomName: string, members: Collection<Snowflake, GuildMember>) {
 		return (
 			{
 				type: 'context',
@@ -40,7 +40,7 @@ export class Notifier {
 		);
 	}
 
-	async postMessage(
+	private async postMessage(
 		{type, username, memberSize, roomId, roomName, roomMembers}: {
 			type: 'join' | 'leave',
 			username: string,

--- a/discord/notifier.ts
+++ b/discord/notifier.ts
@@ -1,4 +1,4 @@
-import type {ContextBlock, WebClient} from '@slack/web-api';
+import type {ChatPostMessageArguments, ContextBlock, WebClient} from '@slack/web-api';
 import {Mutex} from 'async-mutex';
 import type {Collection, GuildMember, Snowflake, VoiceState} from 'discord.js';
 
@@ -7,27 +7,10 @@ const mutex = new Mutex();
 export class Notifier {
 	slack: WebClient;
 
-	lastNotificationTimestamp: string | null = null;
-
-	roomNotifyCache = {
-		lastUnixTime: 0, usernames: <string[]>[], ts: '', action: '',
-	};
-
-	notifyCacheLimit = 60000; // 1min
+	channelNotificationTimestamps: Map<string, string> = new Map();
 
 	constructor(slack: WebClient) {
 		this.slack = slack;
-	}
-
-	usernameSummarizer(usernames: string[]) {
-		if (usernames.length >= 3) {
-			return `＊${usernames[0]}＊, ＊${usernames[1]}＊, ほか${usernames.length - 2}名`;
-		} else if (usernames.length === 2) {
-			return `＊${usernames[0]}＊, ＊${usernames[1]}＊`;
-		} else if (usernames.length === 1) {
-			return `＊${usernames[0]}＊`;
-		}
-		return '';
 	}
 
 	getMembersBlock(roomName: string, members: Collection<Snowflake, GuildMember>) {
@@ -58,40 +41,19 @@ export class Notifier {
 	}
 
 	async postMessage(
-		{text, count, rooms, ts}: {
-			text: string,
-			count: number,
-			rooms: {
-				name: string,
-				members: Collection<string, GuildMember>,
-			}[],
-			ts: string,
+		{type, username, memberSize, roomId, roomName, roomMembers}: {
+			type: 'join' | 'leave',
+			username: string,
+			memberSize: number,
+			roomId: string,
+			roomName: string,
+			roomMembers: Collection<string, GuildMember>,
 		},
 	) {
-		const countText = count === null ? '' : `現在のアクティブ人数 ${count}人`;
+		const text = `＊${username}＊が${roomName}${type === 'join' ? 'にログイン' : 'からログアウト'}しました`;
+		const countText = `現在のアクティブ人数 ${memberSize}人`;
 
-		if (ts) {
-			const result = await this.slack.chat.update({
-				ts,
-				channel: process.env.CHANNEL_SANDBOX,
-				username: 'Discord',
-				icon_emoji: ':discord:',
-				text: `${text}\n${countText}`,
-				blocks: [
-					{
-						type: 'section',
-						text: {
-							type: 'mrkdwn',
-							text,
-						},
-					},
-					...rooms.map((room) => this.getMembersBlock(room.name, room.members)),
-				],
-			});
-			return result;
-		}
-
-		const response = await this.slack.chat.postMessage({
+		const postArguments: ChatPostMessageArguments = {
 			channel: process.env.CHANNEL_SANDBOX,
 			username: 'Discord',
 			icon_emoji: ':discord:',
@@ -104,10 +66,28 @@ export class Notifier {
 						text,
 					},
 				},
-				...rooms.map((room) => this.getMembersBlock(room.name, room.members)),
+				this.getMembersBlock(roomName, roomMembers),
 			],
-		});
-		return response;
+		};
+
+		const [sandboxPostResponse] = await Promise.all([
+			this.slack.chat.postMessage(postArguments),
+			this.slack.chat.postMessage({
+				...postArguments,
+				channel: process.env.CHANNEL_DISCORD,
+			}),
+		]);
+
+		const timestamp = this.channelNotificationTimestamps.get(roomId);
+
+		if (timestamp) {
+			await this.slack.chat.delete({
+				channel: process.env.CHANNEL_SANDBOX,
+				ts: timestamp,
+			});
+		}
+
+		this.channelNotificationTimestamps.set(roomId, sandboxPostResponse.ts);
 	}
 
 	async voiceStateUpdate(oldState: VoiceState, newState: VoiceState) {
@@ -116,98 +96,34 @@ export class Notifier {
 		}
 
 		const username = oldState.member.displayName;
-		const eventTime = Date.now();
 
 		await mutex.runExclusive(async () => {
+			if (oldState.channel?.id === newState.channel?.id) {
+				return;
+			}
+
 			// leave
-			if (oldState.channel !== null && newState.channel === null) {
-				const roomName = oldState.channel.name;
-				const roomId = oldState.channel.id;
-				const count = oldState.channel.members.size;
-				const actionName = `leave-${roomId}`;
-				const update = this.roomNotifyCache.lastUnixTime + this.notifyCacheLimit > eventTime && this.roomNotifyCache.action === actionName;
-
-				if (update) {
-					this.roomNotifyCache.usernames.push(username);
-				} else {
-					this.roomNotifyCache.usernames = [username];
-				}
-
-				const response = await this.postMessage({
-					text: `${this.usernameSummarizer(this.roomNotifyCache.usernames)}が<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${roomId}|${roomName}>からログアウトしました`,
-					count,
-					rooms: [{name: roomName, members: oldState.channel.members}],
-					ts: update ? this.roomNotifyCache.ts : null,
+			if (oldState.channel !== null) {
+				await this.postMessage({
+					type: 'leave',
+					username,
+					memberSize: oldState.channel.members.size,
+					roomId: oldState.channel.id,
+					roomName: oldState.channel.name,
+					roomMembers: oldState.channel.members,
 				});
-
-				if (!update && response.ok) {
-					this.roomNotifyCache.ts = response.ts;
-				}
-
-				this.roomNotifyCache.action = actionName;
-				this.roomNotifyCache.lastUnixTime = eventTime;
 			}
 
 			// join
-			if (newState.channel !== null && oldState.channel === null) {
-				const roomName = newState.channel.name;
-				const roomId = newState.channel.id;
-				const count = newState.channel.members.size;
-				const actionName = `join-${roomId}`;
-				const update = this.roomNotifyCache.lastUnixTime + this.notifyCacheLimit > eventTime && this.roomNotifyCache.action === actionName;
-
-				if (update) {
-					this.roomNotifyCache.usernames.push(username);
-				} else {
-					this.roomNotifyCache.usernames = [username];
-				}
-
-				const response = await this.postMessage({
-					text: `${this.usernameSummarizer(this.roomNotifyCache.usernames)}が<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${roomId}|${roomName}>にログインしました`,
-					count,
-					rooms: [{name: roomName, members: newState.channel.members}],
-					ts: update ? this.roomNotifyCache.ts : null,
+			if (newState.channel !== null) {
+				await this.postMessage({
+					type: 'join',
+					username,
+					memberSize: newState.channel.members.size,
+					roomId: newState.channel.id,
+					roomName: newState.channel.name,
+					roomMembers: newState.channel.members,
 				});
-
-				if (!update && response.ok) {
-					this.roomNotifyCache.ts = response.ts;
-				}
-
-				this.roomNotifyCache.action = actionName;
-				this.roomNotifyCache.lastUnixTime = eventTime;
-			}
-
-			// move
-			if (oldState.channel !== null && newState.channel !== null && oldState.channel.id !== newState.channel.id) {
-				const newRoomName = newState.channel.name;
-				const newRoomId = newState.channel.id;
-				const oldRoomName = oldState.channel.name;
-				const oldRoomId = oldState.channel.id;
-				const actionName = `join-${oldRoomId}-${newRoomId}`;
-				const update = this.roomNotifyCache.lastUnixTime + this.notifyCacheLimit > eventTime && this.roomNotifyCache.action === actionName;
-
-				if (update) {
-					this.roomNotifyCache.usernames.push(username);
-				} else {
-					this.roomNotifyCache.usernames = [username];
-				}
-
-				const response = await this.postMessage({
-					text: `${this.usernameSummarizer(this.roomNotifyCache.usernames)}が<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${oldRoomId}|${oldRoomName}>から<https://discord.com/channels/${process.env.DISCORD_SERVER_ID}/${newRoomId}|${newRoomName}>に移動しました`,
-					count: null,
-					rooms: [
-						{name: oldRoomName, members: oldState.channel.members},
-						{name: newRoomName, members: newState.channel.members},
-					],
-					ts: update ? this.roomNotifyCache.ts : null,
-				});
-
-				if (!update && response.ok) {
-					this.roomNotifyCache.ts = response.ts;
-				}
-
-				this.roomNotifyCache.action = actionName;
-				this.roomNotifyCache.lastUnixTime = eventTime;
 			}
 		});
 	}


### PR DESCRIPTION
sandboxに対するdiscord通知が多すぎるという問題を受け、sandboxに対するdiscord通知をする際、同じチャンネルのものについては1つ前のものを削除するよう修正しました。また、discord通知専用チャンネル#_discordを設け、そちらにDiscordの完全なログが残るようにしました。