### PR TITLE
"X" 発言に Twitter スタンプを送る

### DIFF
--- a/sushi-bot/index.ts
+++ b/sushi-bot/index.ts
@@ -357,6 +357,12 @@ export default async function ({eventClient, webClient: slack}: SlackInterface) 
 			if (allText.match(/twitter(?!\.com)/i)) {
 				slack.reactions.add({name: 'x-logo', channel, timestamp})
 			}
+        }
+        
+        {
+			if (allText.match(/\bx(?!\.com)\b/i)) {
+				slack.reactions.add({name: 'twitter', channel, timestamp})
+			}
 		}
 	});
 


### PR DESCRIPTION
"Twitter" を含むメッセージに対して "X" スタンプが来るのに対抗して，"X"（単語中のものは含まない）を含むメッセージに対して "Twitter" スタンプを送るようにしました
初めて TSG の slackbot をいじるので粗祖をしていたらごめんなさい
デバッグとかしていませんが多分動くと信じてます
![screenshot-146](https://github.com/user-attachments/assets/00917225-759b-4d63-984b-0ea5de62cbba)

