### PR TITLE
ハイパーロボットをスレッド化

### DIFF
--- a/ricochet-robots/SinglePlayRicochetRobot.ts
+++ b/ricochet-robots/SinglePlayRicochetRobot.ts
@@ -1,0 +1,291 @@
+import { AteQuiz, AteQuizProblem } from '../atequiz';
+import { round } from 'lodash';
+import type { Message } from '@slack/web-api/dist/response/ConversationsHistoryResponse';
+import { SlackInterface } from '../lib/slack';
+import * as image from './image';
+import * as board from './board';
+import { ChatPostMessageArguments, KnownBlock, WebAPICallOptions } from '@slack/web-api';
+import { unlock } from '../achievements';
+import assert from 'assert';
+
+interface SingleRicochetRobotConstructor {
+	slackClients: SlackInterface,
+	channel: string,
+	depth: number,
+	size: {h: number, w: number},
+	numOfWalls: number,
+	threadTs: string,
+	originalUser: string,
+}
+
+export default class SinglePlayRicochetRobot extends AteQuiz {
+	startTime: number;
+	endTime: number;
+	boardData: board.Board;
+	answer: board.Move[];
+	originalUser: string;
+
+	constructor(
+		slackClients: SlackInterface,
+		problem: AteQuizProblem,
+		boardData: board.Board,
+		answer: board.Move[],
+		originalUser: string,
+	) {
+		super(slackClients, problem, {
+			username: 'hyperrobot',
+			icon_emoji: ':robot_face:',
+		});
+		this.boardData = boardData;
+		this.answer = answer;
+		this.originalUser = originalUser;
+	}
+
+	static async init({slackClients, channel, depth, size, numOfWalls, threadTs, originalUser}: SingleRicochetRobotConstructor) {
+		const [boardData, answer] = await board.getBoard({depth: (depth || 1000) , size, numOfWalls});
+		const imageUrl = await image.upload(boardData);
+		const quizText = `${answer.length}手詰めです`;
+
+		const singleRicochetRobot = new SinglePlayRicochetRobot(slackClients, {
+			problemMessage: {
+				channel,
+				text: quizText,
+				blocks: [
+					{
+						type: 'section',
+						text: {
+							type: 'plain_text',
+							text: quizText,
+						},
+						accessory: {
+							type: 'image',
+							image_url: imageUrl,
+							alt_text: '',
+						},
+					},
+				],
+				thread_ts: threadTs,
+				reply_broadcast: true,
+			},
+			hintMessages: [],
+			immediateMessage: {
+				channel,
+				text: 'このスレッドに回答してね！',
+				blocks: [
+					{
+						type: 'section',
+						text: {
+							type: 'plain_text',
+							text: 'このスレッドに回答してね！',
+						},
+					},
+					{
+						type: 'image',
+						image_url: imageUrl,
+						alt_text: '',
+					},
+				],
+			},
+			solvedMessage: {
+				channel,
+				text: '',
+				reply_broadcast: true,
+			},
+			unsolvedMessage: {
+				channel,
+				text: '',
+				reply_broadcast: true,
+			},
+			correctAnswers: [],
+		}, boardData, answer, originalUser);
+
+		return singleRicochetRobot;
+	}
+
+	waitSecGen() {
+		return Infinity;
+	}
+
+	start() {
+		this.startTime = Date.now();
+		return super.start();
+	}
+
+	postMessage(message: Partial<ChatPostMessageArguments>) {
+		return this.slack.chat.postMessage({
+			...message,
+			channel: this.problem.problemMessage.channel,
+			thread_ts: this.problem.problemMessage.thread_ts,
+			username: 'hyperrobot',
+			icon_emoji: ':robot_face:',
+		});
+	}
+
+	async postNotSolvedMessage(board: board.Board) {
+		const message = '解けてませんね:thinking_face:';
+		const imageUrl = await image.upload(board);
+		await this.postMessage({
+			text: message,
+			blocks: [
+				{
+					type: 'section',
+					text: {
+						type: 'plain_text',
+						text: '解けてませんね:thinking_face:',
+					},
+				},
+				{
+					type: 'image',
+					image_url: imageUrl,
+					alt_text: '',
+				},
+			],
+		});
+	}
+
+	judge(answer: string) {
+		if (board.iscommand(answer)) {
+			const command = board.str2command(answer);
+			if(!command.isMADE && command.moves.length > this.answer.length){
+				const message = [
+					`この問題は${this.answer.length}手詰めだよ。その手は${command.moves.length}手かかってるよ:thinking_face:`,
+					'もし最短でなくてもよいなら、手順のあとに「まで」をつけてね。'
+				].join('\n');
+				this.postMessage({
+					text: message,
+				});
+				return false;
+			}
+			const playerBoard = this.boardData.clone(); 
+			playerBoard.movecommand(command.moves);
+			if(playerBoard.iscleared()){
+				this.endTime = Date.now();
+				return true;
+			} else {
+				this.postNotSolvedMessage(playerBoard);
+				return false;
+			}
+		}
+		return false;
+	}
+
+	async solvedMessageGen(message: Message) {
+		const answer = message.text as string;
+		assert(board.iscommand(answer), 'answer is not command');
+
+		const command = board.str2command(answer);
+		const playerBoard = this.boardData.clone(); 
+		playerBoard.movecommand(command.moves);
+		assert(playerBoard.iscleared(), 'playerBoard is not cleared');
+
+		let comment = `<@${message.user}> 正解です!:tada:`;
+		if(command.moves.length === this.answer.length){
+			comment += 'さらに最短勝利です!:waiwai:';
+		}
+
+		return {
+			channel: this.problem.solvedMessage.channel,
+			text: comment,
+			reply_broadcast: true,
+		};
+	}
+
+	async answerMessageGen(message: Message) {
+		const answer = message.text as string;
+		assert(board.iscommand(answer), 'answer is not command');
+
+		const command = board.str2command(answer);
+		const playerBoard = this.boardData.clone(); 
+		playerBoard.movecommand(command.moves);
+		assert(playerBoard.iscleared(), 'playerBoard is not cleared');
+
+		const blocks: KnownBlock[] = [];
+
+		const passedMs = (this.endTime - this.startTime) / 1000;
+
+		let comment = '';
+		if (command.moves.length < this.answer.length){
+			comment += 'というか:bug:ってますね...????? :hakatashi:に連絡してください。';
+			await unlock(message.user, 'ricochet-robots-debugger');
+		}
+
+		const playerBoardUrl = await image.upload(playerBoard);
+
+		if (comment.length > 0) {
+			blocks.push({
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: comment,
+				},
+			});
+		}
+
+		blocks.push( {
+			type: 'image',
+			image_url: playerBoardUrl,
+			alt_text: '',
+		});
+		
+		const botcomment = (command.moves.length > this.answer.length) ?
+													`実は${this.answer.length}手でたどり着けるんです。\n${board.logstringfy(this.answer)}`:
+													`僕の見つけた手順です。\n${board.logstringfy(this.answer)}`;
+		
+		const botBoard = this.boardData.clone();
+		botBoard.movecommand(this.answer);
+		const botBoardUrl = await image.upload(botBoard);
+
+		blocks.push(
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: botcomment,
+				},
+			},
+			{
+				type: 'image',
+				image_url: botBoardUrl,
+				alt_text: '',
+			},
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `経過時間: ${round(passedMs, 3)} 秒`,
+				},
+			}
+		);
+		
+		if(command.moves.length <= this.answer.length){
+			await unlock(message.user, 'ricochet-robots-clear-shortest');
+			if(this.answer.length >= 10){
+				await unlock(message.user, 'ricochet-robots-clear-shortest-over10');
+			}
+			if(this.answer.length >= 15){
+				await unlock(message.user, 'ricochet-robots-clear-shortest-over15');
+			}
+			if(this.answer.length >= 20){
+				await unlock(message.user, 'ricochet-robots-clear-shortest-over20');
+			}
+		}
+		await unlock(message.user, 'ricochet-robots-clear');
+		if (this.answer.length >= 8 && command.moves.length <= this.answer.length) {
+			if (passedMs <= this.answer.length * 10 * 1000) {
+				await unlock(message.user, 'ricochet-robots-clear-in-10sec-per-move-over8');
+			}
+			if (passedMs <= this.answer.length * 5 * 1000) {
+				await unlock(message.user, 'ricochet-robots-clear-in-5sec-per-move-over8');
+			}
+			if (passedMs <= this.answer.length * 1 * 1000) {
+				await unlock(message.user, 'ricochet-robots-clear-in-1sec-per-move-over8');
+			}
+		}
+
+		return {
+			channel: this.problem.solvedMessage.channel,
+			text: comment,
+			blocks,
+		};
+	}
+}

--- a/ricochet-robots/SinglePlayRicochetRobot.ts
+++ b/ricochet-robots/SinglePlayRicochetRobot.ts
@@ -188,7 +188,7 @@ export default class SinglePlayRicochetRobot extends AteQuiz {
 		playerBoard.movecommand(command.moves);
 		assert(playerBoard.iscleared(), 'playerBoard is not cleared');
 
-		let comment = `<@${message.user}> 正解です!:tada:`;
+		let comment = '正解です!:tada:';
 		if (command.moves.length === this.answer.length) {
 			comment += 'さらに最短勝利です!:waiwai:';
 		}

--- a/ricochet-robots/board.ts
+++ b/ricochet-robots/board.ts
@@ -204,7 +204,7 @@ export const logstringfy = (log: Move[]) => {
 	return log.map(v => colournames[v.c]+directionnames[v.d]).join();
 };
 
-export const getBoard = async (boardspec: BoardSpec) => {
+export const getBoard = async (boardspec: BoardSpec): Promise<[Board, Move[]]> => {
 	const data = await rust_proxy.get_data(boardspec);
 	let lines = data.split('\n').filter((line) => line);
 	lines = lines.slice(lines.length-4,lines.length);

--- a/ricochet-robots/image.ts
+++ b/ricochet-robots/image.ts
@@ -223,7 +223,7 @@ async function uploadbuffer(image: Buffer) {
 			}
 		}).end(image);
 	});
-	return result.secure_url;
+	return result;
 }
 
 export const upload = async (data: Board) => {

--- a/ricochet-robots/index.test.ts
+++ b/ricochet-robots/index.test.ts
@@ -43,6 +43,9 @@ describe('hyperrobot', () => {
 			cloudinaryMock.url = 'https://hoge.com/hoge.png';
 			const {username, attachments, blocks, text,} = await slack.getResponseTo('ハイパーロボット');
 
+			expect(get_data).toBeCalledTimes(1);
+			expect(get_data).toBeCalledWith({depth: 1000, size: {h: 7, w: 9}, numOfWalls: 15});
+
 			expect(username).toBe('hyperrobot');
 			expect(text).toContain('10手詰めです');
 			expect(attachments).toBe(undefined);

--- a/ricochet-robots/index.test.ts
+++ b/ricochet-robots/index.test.ts
@@ -41,24 +41,24 @@ describe('hyperrobot', () => {
 	describe('base', () => {
 		it('responds to ハイパーロボット', async () => {
 			cloudinaryMock.url = 'https://hoge.com/hoge.png';
-			const {username, attachments, text,} = await slack.getResponseTo('ハイパーロボット');
+			const {username, attachments, blocks, text,} = await slack.getResponseTo('ハイパーロボット');
 
 			expect(username).toBe('hyperrobot');
 			expect(text).toContain('10手詰めです');
 			expect(attachments).toBe(undefined);
+			expect(blocks).toHaveLength(1);
+			expect(blocks[0].type).toBe('section');
+			expect((blocks[0] as SectionBlock).accessory?.type).toBe('image');
 		}, 60000);
 	});
 	describe('battle', () => {
 		it('responds to ハイパーロボットバトル & responds to first bidding', async () => {
 			cloudinaryMock.url = 'https://hoge.com/hoge.png';
 			{
-				const {username, attachments, blocks, text,} = await slack.getResponseTo('ハイパーロボットバトル');
+				const {username, attachments, text,} = await slack.getResponseTo('ハイパーロボットバトル');
 				expect(username).toBe('hyperrobot');
 				expect(text).toContain(':question:手詰めです');
 				expect(attachments).toHaveLength(1);
-				expect(blocks).toHaveLength(1);
-				expect(blocks[0].type).toBe('section');
-				expect((blocks[0] as SectionBlock).accessory?.type).toBe('image');
 			}
 			{
 				const {username, text,} = await slack.getResponseTo('3');

--- a/ricochet-robots/index.test.ts
+++ b/ricochet-robots/index.test.ts
@@ -13,6 +13,7 @@ import Slack from '../lib/slackMock';
 
 import fs from 'fs';
 import path from 'path';
+import type { SectionBlock } from '@slack/web-api';
 
 const get_data = rust_proxy.get_data as jest.MockedFunction<typeof rust_proxy.get_data>;
 get_data.mockImplementation((x) => {
@@ -44,17 +45,20 @@ describe('hyperrobot', () => {
 
 			expect(username).toBe('hyperrobot');
 			expect(text).toContain('10手詰めです');
-			expect(attachments).toHaveLength(1);
+			expect(attachments).toBe(undefined);
 		}, 60000);
 	});
 	describe('battle', () => {
 		it('responds to ハイパーロボットバトル & responds to first bidding', async () => {
 			cloudinaryMock.url = 'https://hoge.com/hoge.png';
 			{
-				const {username, attachments, text,} = await slack.getResponseTo('ハイパーロボットバトル');
+				const {username, attachments, blocks, text,} = await slack.getResponseTo('ハイパーロボットバトル');
 				expect(username).toBe('hyperrobot');
 				expect(text).toContain(':question:手詰めです');
 				expect(attachments).toHaveLength(1);
+				expect(blocks).toHaveLength(1);
+				expect(blocks[0].type).toBe('section');
+				expect((blocks[0] as SectionBlock).accessory?.type).toBe('image');
 			}
 			{
 				const {username, text,} = await slack.getResponseTo('3');

--- a/ricochet-robots/index.ts
+++ b/ricochet-robots/index.ts
@@ -190,9 +190,9 @@ export default (slackClients: SlackInterface) => {
 						return;
 					}
 
-					let depth: number | undefined = parseInt(matches[2]);
+					let depth: number = parseInt(matches[2]);
 					if (Number.isNaN(depth)) {
-						depth = undefined;
+						depth = 1000;
 					} else if (depth >= 1000) {
 						depth = 1000;
 					} else if (depth <= 0) {

--- a/ricochet-robots/index.ts
+++ b/ricochet-robots/index.ts
@@ -105,9 +105,10 @@ export default (slackClients: SlackInterface) => {
 			else{
 				const answerBoard = state.board.clone();
 				answerBoard.movecommand(state.answer);
+				const imageData = await image.upload(answerBoard);
 				await postmessage(
 					`だれも正解できなかったよ:cry:\n正解は ${board.logstringfy(state.answer)} の${state.answer.length}手だよ。`,
-					await image.upload(answerBoard)
+					imageData.secure_url
 				);
 				state = undefined;
 			}
@@ -139,7 +140,7 @@ export default (slackClients: SlackInterface) => {
 			}
 			const playerBoard = state.board.clone(); 
 			playerBoard.movecommand(cmd.moves);
-			const url = await image.upload(playerBoard);
+			const imageData = await image.upload(playerBoard);
 			if(playerBoard.iscleared()){
 				let comment = "正解です!:tada:";
 				if(cmd.moves.length === state.answer.length){
@@ -149,7 +150,7 @@ export default (slackClients: SlackInterface) => {
 					comment += "というか:bug:ってますね...?????  :satos:に連絡してください。";
 					await unlock(message.user, 'ricochet-robots-debugger');
 				}
-				await postmessage(comment,url);
+				await postmessage(comment,imageData.secure_url);
 				
 				const botcomment = (cmd.moves.length > state.answer.length) ?
 				                     `実は${state.answer.length}手でたどり着けるんです。\n${board.logstringfy(state.answer)}`:
@@ -157,7 +158,8 @@ export default (slackClients: SlackInterface) => {
 				
 				const botBoard = state.board.clone();
 				botBoard.movecommand(state.answer);
-				await postmessage(botcomment, await image.upload(botBoard));
+				const botBoardImageData = await image.upload(botBoard);
+				await postmessage(botcomment, botBoardImageData.secure_url);
 				
 				if(cmd.moves.length <= state.answer.length){
 					await unlock(message.user, 'ricochet-robots-clear-shortest');
@@ -174,7 +176,7 @@ export default (slackClients: SlackInterface) => {
 				return true;
 			}
 			else{
-				await postmessage("解けてませんね:thinking_face:",url);
+				await postmessage("解けてませんね:thinking_face:",imageData.secure_url);
 				return false;
 			}
 		}
@@ -258,7 +260,8 @@ export default (slackClients: SlackInterface) => {
 							},
 						};
 					}
-					await postmessage(`${state.battles.isbattle ? ":question:": state.answer.length}手詰めです`,await image.upload(state.board));
+					const imageData = await image.upload(state.board);
+					await postmessage(`${state.battles.isbattle ? ":question:": state.answer.length}手詰めです`,imageData.secure_url);
 					if(isbattle){
 						await unlock(message.user, 'ricochet-robots-buttle-play');
 					}


### PR DESCRIPTION
## したこと

1人プレイのハイパーロボットをスレッド化した

### ricochet-robots

* スレッド化した1人プレイのハイパーロボットのロジックを新たなクラス SinglePlayRicochetRobot に実装し、ricochet-robots/index.tsから呼び出した
* ricochet-robots/index.tsにある1人プレイのコードはとりあえず残してある (そのうち消す)

### AteQuiz

* answerMessageGenでanswerMessageを動的に生成できるようにした
* solvedMessageGenをasync関数でオーバーライドできるようにした
* 最初のメッセージをもう一度投稿するrepostProblemMessage関数を実装した

## スクショ

### スレッド外での見え方

![image](https://github.com/user-attachments/assets/431daeee-b646-47b9-9b58-a18947ee0422)

### 最短の場合

![image](https://github.com/user-attachments/assets/9ba6aeba-88b8-495e-b6f9-56695b9fcb91)

### 最短でない場合

![image](https://github.com/user-attachments/assets/1f974c31-9e2d-4cb3-b1b6-8c0252b4d853)

