### PR TITLE
topic: topicの長さ制限の仕様変更に対応

### DIFF
--- a/topic/index.test.ts
+++ b/topic/index.test.ts
@@ -1,0 +1,184 @@
+/* eslint-disable callback-return */
+/* eslint-disable node/callback-return */
+/* eslint-disable import/imports-first */
+/* eslint-disable import/first */
+/* eslint-env jest */
+
+jest.mock('../lib/state');
+jest.mock('../lib/slack');
+jest.mock('../lib/slackUtils', () => ({
+	__esModule: true,
+	getReactions: jest.fn(),
+}));
+jest.mock('../lib/firestore', () => ({
+	__esModule: true,
+	default: {
+		collection: jest.fn().mockReturnValue({
+			doc: jest.fn().mockReturnValue({
+				get: jest.fn(),
+				set: jest.fn(),
+				update: jest.fn(),
+			}),
+		}),
+		runTransaction: jest.fn(),
+	},
+}));
+
+import type {firestore} from 'firebase-admin';
+import {set} from 'lodash';
+import db from '../lib/firestore';
+import Slack from '../lib/slackMock';
+import {getReactions} from '../lib/slackUtils';
+import State from '../lib/state';
+import {Deferred} from '../lib/utils';
+import topicHandler, {addLike, removeLike} from './index';
+
+const runTransaction = db.runTransaction as jest.MockedFunction<typeof db.runTransaction>;
+
+const FAKE_SANDBOX = 'C123456789';
+
+describe('topic', () => {
+	describe('index.ts', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		describe('addLike', () => {
+			it('should add a like to the message', async () => {
+				const mockTransaction = {
+					get: jest.fn(),
+					update: jest.fn(),
+				};
+				const mockDoc = {
+					exists: true,
+					get: jest.fn().mockReturnValue([]),
+				};
+				runTransaction.mockImplementation(async (callback) => {
+					await callback(mockTransaction as unknown as firestore.Transaction);
+				});
+				mockTransaction.get.mockResolvedValue(mockDoc);
+
+				await addLike('user1', '12345');
+
+				expect(mockTransaction.get).toBeCalledWith(db.collection('topic_messages').doc('12345'));
+				expect(mockTransaction.update).toBeCalledWith(db.collection('topic_messages').doc('12345'), {likes: ['user1']});
+			});
+
+			it('should not add a like if the message does not exist', async () => {
+				const mockTransaction = {
+					get: jest.fn(),
+					update: jest.fn(),
+				};
+				const mockDoc = {
+					exists: false,
+				};
+				runTransaction.mockImplementation(async (callback) => {
+					await callback(mockTransaction as unknown as firestore.Transaction);
+				});
+				mockTransaction.get.mockResolvedValue(mockDoc);
+
+				await addLike('user1', '12345');
+
+				expect(mockTransaction.get).toBeCalledWith(db.collection('topic_messages').doc('12345'));
+				expect(mockTransaction.update).not.toBeCalled();
+			});
+		});
+
+		describe('removeLike', () => {
+			it('should remove a like from the message', async () => {
+				const mockTransaction = {
+					get: jest.fn(),
+					update: jest.fn(),
+				};
+				const mockDoc = {
+					exists: true,
+					get: jest.fn().mockReturnValue(['user1']),
+				};
+				runTransaction.mockImplementation(async (callback) => {
+					await callback(mockTransaction as unknown as firestore.Transaction);
+				});
+				mockTransaction.get.mockResolvedValue(mockDoc);
+
+				await removeLike('user1', '12345');
+
+				expect(mockTransaction.get).toBeCalledWith(db.collection('topic_messages').doc('12345'));
+				expect(mockTransaction.update).toBeCalledWith(db.collection('topic_messages').doc('12345'), {likes: []});
+			});
+
+			it('should not remove a like if the message does not exist', async () => {
+				const mockTransaction = {
+					get: jest.fn(),
+					update: jest.fn(),
+				};
+				const mockDoc = {
+					exists: false,
+				};
+				runTransaction.mockImplementation(async (callback) => {
+					await callback(mockTransaction as unknown as firestore.Transaction);
+				});
+				mockTransaction.get.mockResolvedValue(mockDoc);
+
+				await removeLike('user1', '12345');
+
+				expect(mockTransaction.get).toBeCalledWith(db.collection('topic_messages').doc('12345'));
+				expect(mockTransaction.update).not.toBeCalled();
+			});
+		});
+
+		describe('topicHandler', () => {
+			it('should initialize state and set topic', async () => {
+				const mockSlack = new Slack();
+
+				const converastionsInfo = mockSlack.webClient.conversations.info as jest.MockedFunction<typeof mockSlack.webClient.conversations.info>;
+				converastionsInfo.mockResolvedValue({
+					ok: true,
+					channel: {
+						topic: {
+							value: 'Current Topic',
+						},
+					},
+				});
+
+				const conversationsHistory = mockSlack.webClient.conversations.history as jest.MockedFunction<typeof mockSlack.webClient.conversations.history>;
+				conversationsHistory.mockResolvedValue({
+					ok: true,
+					messages: [{
+						ts: '12345',
+						text: 'New Topic',
+					}],
+				});
+
+				const setTopic = mockSlack.webClient.conversations.setTopic as jest.MockedFunction<typeof mockSlack.webClient.conversations.setTopic>;
+				const setTopicDeferred = new Deferred();
+				setTopic.mockImplementation(() => {
+					setTopicDeferred.resolve(null);
+					return Promise.resolve({ok: true});
+				});
+
+				(getReactions as jest.MockedFunction<typeof getReactions>).mockResolvedValue({
+					koresuki: ['user1', 'user2', 'user3', 'user4', 'user5'],
+				});
+
+				process.env.CHANNEL_SANDBOX = FAKE_SANDBOX;
+
+				await topicHandler(mockSlack);
+
+				mockSlack.eventClient.emit('reaction_added', {
+					item: {
+						channel: FAKE_SANDBOX,
+						ts: '12345',
+					},
+					reaction: 'koresuki',
+				});
+
+				await setTopicDeferred.promise;
+
+				expect(mockSlack.webClient.conversations.info).toBeCalledWith({channel: process.env.CHANNEL_SANDBOX});
+				expect(mockSlack.webClient.conversations.setTopic).toBeCalledWith({
+					channel: process.env.CHANNEL_SANDBOX,
+					topic: 'Current Topic／New Topic',
+				});
+			});
+		});
+	});
+});

--- a/topic/index.ts
+++ b/topic/index.ts
@@ -23,8 +23,8 @@ const isQualifiableMessage = (message: Message) => {
 	}
 
 	const [line] = lines;
-	const lineLength = Buffer.from(line).length;
-	return lineLength >= 1 && lineLength <= 100;
+	const lineLength = line.length;
+	return lineLength >= 1 && lineLength <= 60;
 };
 
 interface StateObj {
@@ -82,7 +82,7 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
 		const topics = [headline];
 		for (const topic of [newTopic, ...currentTopics]) {
 			topics.push(topic);
-			const newTopicText = topics.join(' / ');
+			const newTopicText = topics.join('／');
 			if (newTopicText.length > 250) {
 				break;
 			}
@@ -128,7 +128,7 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
 		if (message === undefined) {
 			return;
 		}
-		
+
 		// スレッド内の発言はconversations.historyで取得できないため正しいメッセージが取得できない場合がある
 		if (event.item.ts !== message?.ts) {
 			return;

--- a/topic/index.ts
+++ b/topic/index.ts
@@ -83,7 +83,7 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
 		for (const topic of [newTopic, ...currentTopics]) {
 			topics.push(topic);
 			const newTopicText = topics.join(' / ');
-			if (Buffer.from(newTopicText).length > 250) {
+			if (newTopicText.length > 250) {
 				break;
 			}
 			topicText = newTopicText;


### PR DESCRIPTION
Slackのtopicの長さ制限がいつの間にか250バイトから250文字になっていたので、最大でその長さまで使い切るよう修正

ついでにtopic入りする発言の長さ制限を100バイトから60文字にした (日本語の場合約1.8倍の長さまで緩和)