### PR TITLE
"X" 発言に Twitter スタンプを送る

### DIFF
--- a/sushi-bot/index.test.js
+++ b/sushi-bot/index.test.js
@@ -354,6 +354,37 @@ it('does not react to "twitter.com"', async () => {
 	expect(slack.webClient.reactions.add).not.toHaveBeenCalled();
 });
 
+it('reacts to "X" with :twitter:', () => new Promise((resolve) => {
+	slack.on('reactions.add', ({name, channel, timestamp}) => {
+		expect(name).toBe('twitter');
+		expect(channel).toBe(slack.fakeChannel);
+		expect(timestamp).toBe(slack.fakeTimestamp);
+		resolve();
+	});
+
+	slack.eventClient.emit('message', {
+		channel: slack.fakeChannel,
+		text: '私のXアカウントは@Sqrt10_31622776です',
+		user: slack.fakeUser,
+		ts: slack.fakeTimestamp,
+	});
+}));
+
+it('does not react to words including letter "x" (e.g. "fox", "xylophone")', async () => {
+	slack.webClient.reactions.add.mockReturnValue(null);
+
+	slack.eventClient.emit('message', {
+		channel: slack.fakeChannel,
+		text: 'The quick brown fox jumps over the lazy dog.',
+		user: slack.fakeUser,
+		ts: slack.fakeTimestamp,
+	});
+
+	await new Promise((resolve) => process.nextTick(resolve));
+
+	expect(slack.webClient.reactions.add).not.toHaveBeenCalled();
+});
+
 it('reacts to sushi in an attachment', async () => {
 	slack.on('reactions.add', ({ name, channel, timestamp }) => {
 		expect(name).toBe('sushi');

--- a/sushi-bot/index.ts
+++ b/sushi-bot/index.ts
@@ -358,6 +358,12 @@ export default async function ({eventClient, webClient: slack}: SlackInterface) 
 				slack.reactions.add({name: 'x-logo', channel, timestamp})
 			}
 		}
+
+		{
+			if (allText.match(/\bx(?!\.com)\b/i)) {
+				slack.reactions.add({ name: 'twitter', channel, timestamp})
+			}
+		}
 	});
 
 	schedule.scheduleJob('0 19 * * *', async (date) => {


### PR DESCRIPTION
うまく push できなかったので PR を建て直しました
"Twitter" を含むメッセージに対して "X" スタンプが来るのに対抗して，"X"（単語中のものは含まない）を含むメッセージに対して "Twitter" スタンプを送るようにしました

![image](https://github.com/user-attachments/assets/a221e9c3-0a83-4d78-88cd-0d8dc6930cd0)
