### PR TITLE
city-symbol: Implement ChatGPT hints

### DIFF
--- a/atequiz/index.ts
+++ b/atequiz/index.ts
@@ -123,8 +123,8 @@ export class AteQuiz {
   ) {
     this.eventClient = eventClient;
     this.slack = slack;
-    this.problem = JSON.parse(JSON.stringify(problem));
-    this.postOption = JSON.parse(JSON.stringify(option));
+    this.problem = problem;
+    this.postOption = option ? JSON.parse(JSON.stringify(option)) : option;
 
     assert(
       this.problem.hintMessages.every(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -35,10 +35,12 @@ export class Loader<T> {
 	isTriggered: boolean;
 	loader: () => Promise<T>;
 	private deferred: Deferred<T>;
+	private value: T | null;
 
 	constructor(loader: () => Promise<T>) {
 		this.loader = loader;
 		this.isTriggered = false;
+		this.value = null;
 		this.deferred = new Deferred<T>();
 	}
 
@@ -48,6 +50,7 @@ export class Loader<T> {
 		}
 		this.isTriggered = true;
 		this.loader().then((value) => {
+			this.value = value;
 			this.deferred.resolve(value);
 		}, (error) => {
 			this.deferred.reject(error);
@@ -58,5 +61,9 @@ export class Loader<T> {
 	clear() {
 		this.isTriggered = false;
 		this.deferred = new Deferred<T>();
+	}
+
+	get() {
+		return this.value;
 	}
 }


### PR DESCRIPTION
問題出題から45秒後、ChatGPTヒントが表示されるようにした。

![image](https://github.com/user-attachments/assets/b40c3fa7-5079-4fd5-9390-7749458e9e96)

ついでに市町村名に `|` が含まれてしまう問題を直した。

![image](https://github.com/user-attachments/assets/a697c695-17c4-42da-b7bb-8e48c0d62dac)
