### PR TITLE
nmpz: extended time limit (90s -> 150s)

### DIFF
--- a/nmpz/index.ts
+++ b/nmpz/index.ts
@@ -232,8 +232,8 @@ class NmpzAteQuiz extends AteQuiz {
     return answer.toLowerCase() === this.problem.answer.toLowerCase();
   }
 
-  waitSecGen(_hintIndex: number): number {
-    return 30;
+  waitSecGen(hintIndex: number): number {
+    return hintIndex <= this.problem.hintMessages.length - 1 ? 30 : 90;
   }
 }
 
@@ -289,7 +289,7 @@ function problemFormat(
         text: `ヒント: 画像の地域は${country.subregion}だよ。`,
       },
     ],
-    immediateMessage: { channel: CHANNEL, text: "制限時間: 90秒" },
+    immediateMessage: { channel: CHANNEL, text: "" },
     solvedMessage: {
       channel: CHANNEL,
       text: `<@[[!user]]> 正解！:tada: 正解地点は <${answer_url}|${coordToStr(lat, lng)}> だよ ${emoji}`,
@@ -309,6 +309,7 @@ function problemFormat(
     answer: country.name_official,
     correctAnswers: [country.name_official, country.name_common],
   };
+  problem.immediateMessage.text = `制限時間: ${problem.hintMessages.length * 30 + 90}秒`;
   return problem;
 }
 


### PR DESCRIPTION
* 最後のヒントから正解発表までの時間を 30s -> 90s に延ばしました
* それに伴い、トータルの時間制限が 90s から 2 * 30 + 90 = 150s に伸びます