### PR TITLE
自動生成クイズbotを無効化

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -115,7 +115,7 @@ const productionBots = [
 	'auto-archiver',
 	'city-symbol',
 	'nmpz',
-	'autogen-quiz',
+	// 'autogen-quiz',
 ];
 
 const developmentBots = [


### PR DESCRIPTION
OpenAI API の使用量は Budget Limit 機能を使用して制御していたが、2025年5月30日現在、ダッシュボードから設定項目が消えているように見える。

![image](https://github.com/user-attachments/assets/09d5f9b5-b606-4849-a0d5-e9c9a3cd2ca0)

OpenAI API を際限なく使用されると破産してしまうため、とりあえず一番激しくAPIを利用する自動生成クイズbotの利用を制限することにした。

slackbot側でAPIの使用を制限する仕組みを実装したら戻す予定。
