### PR TITLE
fix: remove package-lock.json from binary attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-package-lock.json binary
 Cargo.lock binary


### PR DESCRIPTION
現状、package-lock.jsonは git diff などの出力で不必要に行数が多く表示されないようにバイナリ比較されるが、以下のようなデメリットがあるためこれを解除する

* WindowsとUnix系OSなど、改行コードの異なるシステム間でファイルを編集した際にファイル全体が置き換わった扱いになる
* sub-dependenciesの更新など、package-lock.jsonの変更をレビューしたいこともある