### PR TITLE
イベントの重複除去処理をEventClientWrapperクラスに移動

### DIFF
--- a/lib/eventClientWrapper.test.ts
+++ b/lib/eventClientWrapper.test.ts
@@ -1,0 +1,110 @@
+import {EventEmitter} from 'events';
+import {EventClientWrapper} from './eventClientWrapper';
+import {getDuplicateEventChecker, DuplicateEventChecker} from './eventDeduplication';
+import {createEventAdapter, type SlackEventAdapter} from '@slack/events-api';
+import {setImmediate} from 'timers/promises';
+
+jest.mock('./eventDeduplication');
+
+const mockedGetDuplicateEventChecker = jest.mocked(getDuplicateEventChecker);
+const mockedDuplicateEventCheckerPrototype = jest.mocked(DuplicateEventChecker.prototype);
+
+describe('EventClientWrapper', () => {
+	let eventAdapter: SlackEventAdapter;
+	let wrapper: EventEmitter;
+
+	beforeEach(() => {
+		eventAdapter = createEventAdapter('test-signing-secret', { includeBody: true });
+		wrapper = new EventClientWrapper(eventAdapter);
+		mockedGetDuplicateEventChecker.mockReturnValue(new DuplicateEventChecker(null));
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should forward non-duplicate events', async () => {
+		const listener = jest.fn();
+		mockedDuplicateEventCheckerPrototype.markEventAsProcessed.mockResolvedValue(false);
+
+		wrapper.on('test_event', listener);
+		
+		const eventData = { event_id: 'test-event-id', team_id: 'test-team' };
+		eventAdapter.emit('test_event', {}, eventData);
+
+		// Give async operations time to complete
+		await setImmediate();
+
+		expect(listener).toHaveBeenCalledWith({}, eventData);
+		expect(mockedDuplicateEventCheckerPrototype.markEventAsProcessed).toHaveBeenCalledWith('test-event-id');
+	});
+
+	it('should block duplicate events', async () => {
+		const listener = jest.fn();
+		mockedDuplicateEventCheckerPrototype.markEventAsProcessed.mockResolvedValue(true);
+
+		wrapper.on('test_event', listener);
+		
+		const eventData = { event_id: 'test-event-id', team_id: 'test-team' };
+		eventAdapter.emit('test_event', {}, eventData);
+
+		// Give async operations time to complete
+		await setImmediate();
+
+		expect(listener).not.toHaveBeenCalled();
+		expect(mockedDuplicateEventCheckerPrototype.markEventAsProcessed).toHaveBeenCalledWith('test-event-id');
+	});
+
+	it('should handle events without event_id', async () => {
+		const listener = jest.fn();
+
+		wrapper.on('test_event', listener);
+		
+		const eventData = { team_id: 'test-team' };
+		eventAdapter.emit('test_event', {}, eventData);
+
+		// Give async operations time to complete
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		expect(listener).toHaveBeenCalledWith({}, eventData);
+		expect(mockedDuplicateEventCheckerPrototype.markEventAsProcessed).not.toHaveBeenCalled();
+	});
+
+	it('should handle multiple listeners for the same event with single deduplication check', async () => {
+		const listener1 = jest.fn();
+		const listener2 = jest.fn();
+		mockedDuplicateEventCheckerPrototype.markEventAsProcessed.mockResolvedValue(false);
+
+		wrapper.on('test_event', listener1);
+		wrapper.on('test_event', listener2);
+		
+		const eventData = { event_id: 'test-event-id', team_id: 'test-team' };
+		eventAdapter.emit('test_event', {}, eventData);
+
+		// Give async operations time to complete
+		await setImmediate();
+
+		expect(listener1).toHaveBeenCalledWith({}, eventData);
+		expect(listener2).toHaveBeenCalledWith({}, eventData);
+		expect(mockedDuplicateEventCheckerPrototype.markEventAsProcessed).toHaveBeenCalledTimes(1);
+	});
+
+	it('should block duplicate events for all listeners', async () => {
+		const listener1 = jest.fn();
+		const listener2 = jest.fn();
+		mockedDuplicateEventCheckerPrototype.markEventAsProcessed.mockResolvedValue(true);
+
+		wrapper.on('test_event', listener1);
+		wrapper.on('test_event', listener2);
+		
+		const eventData = { event_id: 'test-event-id', team_id: 'test-team' };
+		eventAdapter.emit('test_event', {}, eventData);
+
+		// Give async operations time to complete
+		await setImmediate();
+
+		expect(listener1).not.toHaveBeenCalled();
+		expect(listener2).not.toHaveBeenCalled();
+		expect(mockedDuplicateEventCheckerPrototype.markEventAsProcessed).toHaveBeenCalledTimes(1);
+	});
+});

--- a/lib/eventClientWrapper.ts
+++ b/lib/eventClientWrapper.ts
@@ -1,0 +1,71 @@
+import type {SlackEventAdapter} from '@slack/events-api';
+import {getDuplicateEventChecker} from './eventDeduplication';
+import logger from './logger';
+import {EventEmitter} from 'events';
+
+const log = logger.child({ bot: 'EventClientWrapper' });
+
+// Slackのイベント重複除去を行うEventClientのラッパー
+export class EventClientWrapper extends EventEmitter {
+	readonly #eventAdapter: SlackEventAdapter;
+	#registeredEvents: Set<string> = new Set();
+	expressMiddleware: typeof SlackEventAdapter.prototype.expressMiddleware;
+
+	constructor(eventAdapter: SlackEventAdapter) {
+		super();
+		this.#eventAdapter = eventAdapter;
+		this.expressMiddleware = this.#eventAdapter.expressMiddleware.bind(this.#eventAdapter);
+	}
+
+	private setupEventHandler(event: string): void {
+		if (this.#registeredEvents.has(event)) {
+			return;
+		}
+
+		this.#registeredEvents.add(event);
+		
+		this.#eventAdapter.on(event, async (...args: any[]) => {
+			const [, eventBody] = args;
+			const eventId = eventBody?.event_id;
+
+			if (eventId) {
+				const duplicateChecker = getDuplicateEventChecker();
+				const wasAlreadyProcessed = await duplicateChecker.markEventAsProcessed(eventId);
+
+				if (wasAlreadyProcessed) {
+					log.debug(`Duplicate event detected (id: ${eventId}), skipping`, { eventId, event });
+					return;
+				}
+			} else {
+				log.warn('Event without event_id received', { event, teamId: eventBody.team_id });
+			}
+
+			// Emit the event to our own listeners after deduplication
+			this.emit(event, ...args);
+		});
+	}
+
+	on(event: string, listener: (...args: any[]) => void): this {
+		this.setupEventHandler(event);
+		return super.on(event, listener);
+	}
+
+	addListener(event: string, listener: (...args: any[]) => void): this {
+		return this.on(event, listener);
+	}
+
+	once(event: string, listener: (...args: any[]) => void): this {
+		this.setupEventHandler(event);
+		return super.once(event, listener);
+	}
+
+	prependListener(event: string, listener: (...args: any[]) => void): this {
+		this.setupEventHandler(event);
+		return super.prependListener(event, listener);
+	}
+
+	prependOnceListener(event: string, listener: (...args: any[]) => void): this {
+		this.setupEventHandler(event);
+		return super.prependOnceListener(event, listener);
+	}
+}

--- a/lib/eventClientWrapper.ts
+++ b/lib/eventClientWrapper.ts
@@ -8,7 +8,7 @@ const log = logger.child({ bot: 'EventClientWrapper' });
 // Slackのイベント重複除去を行うEventClientのラッパー
 export class EventClientWrapper extends EventEmitter {
 	readonly #eventAdapter: SlackEventAdapter;
-	#registeredEvents: Set<string> = new Set();
+	readonly #registeredEvents: Set<string> = new Set();
 	expressMiddleware: typeof SlackEventAdapter.prototype.expressMiddleware;
 
 	constructor(eventAdapter: SlackEventAdapter) {

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -6,6 +6,7 @@ import * as sqlite from 'sqlite';
 import sqlite3 from 'sqlite3';
 import path from 'path';
 import {TeamEventClient} from './slackEventClient';
+import {EventClientWrapper} from './eventClientWrapper';
 import type {EventEmitter} from 'events';
 import {Deferred} from './utils';
 import {Token} from '../oauth/tokens';
@@ -42,12 +43,9 @@ export interface SlackOauthEndpoint {
 }
 
 export const webClient = new WebClient(process.env.SLACK_TOKEN);
-export const eventClient = createEventAdapter(process.env.SIGNING_SECRET, {includeBody: true});
+export const eventClient = new EventClientWrapper(createEventAdapter(process.env.SIGNING_SECRET, {includeBody: true}));
 export const messageClient = createMessageAdapter(process.env.SIGNING_SECRET);
-export const tsgEventClient = TeamEventClient.create(
-	eventClient,
-	process.env.TEAM_ID,
-);
+export const tsgEventClient = new TeamEventClient(eventClient, process.env.TEAM_ID);
 
 
 const loadTokensDeferred = new Deferred<Token[]>();

--- a/lib/slackCache.ts
+++ b/lib/slackCache.ts
@@ -49,7 +49,7 @@ export default class SlackCache {
 
 	constructor(config: Config) {
 		this.config = config;
-		const teamEventClient = TeamEventClient.create(this.config.eventClient, this.config.token.team_id);
+		const teamEventClient = new TeamEventClient(this.config.eventClient, this.config.token.team_id);
 
 		{
 			// user cache

--- a/lib/slackEventClient.ts
+++ b/lib/slackEventClient.ts
@@ -1,110 +1,30 @@
-import {getDuplicateEventChecker} from './eventDeduplication';
-import logger from './logger';
-import assert from 'assert';
-import type EventEmitter from 'events';
-import { inspect } from 'util';
-
-const log = logger.child({ bot: 'TeamEventClient' });
+import type { EventEmitter } from 'events';
 
 export class TeamEventClient {
 	readonly #eventAdapter: EventEmitter;
 	readonly #team: string;
-	#listeners: Map<string, ((...args: any[]) => void)[]> = new Map();
-	#allTeamListeners: Map<string, ((...args: any[]) => void)[]> = new Map();
-	#registeredEvents: Set<string> = new Set();
-
-	static instances: TeamEventClient[] = [];
-
-	static create(eventAdapter: EventEmitter, team: string) {
-		for (const instance of TeamEventClient.instances) {
-			if (instance.#eventAdapter === eventAdapter && instance.#team === team) {
-				return instance;
-			}
-		}
-
-		const newInstance = new TeamEventClient(eventAdapter, team);
-		TeamEventClient.instances.push(newInstance);
-		return newInstance;
-	}
 
 	// contract: 渡されるeventAdapterは、EventAdapterOptions.includeBodyがtrueでなければならない。
-	private constructor(eventAdapter: EventEmitter, team: string) {
+	constructor(eventAdapter: EventEmitter, team: string) {
 		this.#eventAdapter = eventAdapter;
 		this.#team = team;
 	}
 
-	private registerEventCallback(event: string) {
-		return this.#eventAdapter.on(event, async (...args: any[]) => {
+	// listen on events against all teams.
+	onAllTeam(event: string, listener: (...args: any[]) => void): any {
+		return this.#eventAdapter.on(event, listener);
+	}
+	// listen on events against the team.
+	on(event: string, listener: (...args: any[]) => void): any {
+		return this.#eventAdapter.on(event, (...args: any[]) => {
 			// https://slack.dev/node-slack-sdk/events-api#receive-additional-event-data
 			// https://github.com/slackapi/node-slack-sdk/blob/3e9c483c593d6aa28f6f5680f287722df3327609/packages/events-api/src/http-handler.ts#L212-L223
 			// https://api.slack.com/apis/connections/events-api#the-events-api__receiving-events__events-dispatched-as-json
-			// args: [body.event, body: {team_id: string, event_id?: string}]
-			const [, eventBody] = args;
-
-			const listeners = this.#listeners.get(event) || [];
-			const allTeamListeners = this.#allTeamListeners.get(event) || [];
-			assert(listeners.length > 0 || allTeamListeners.length > 0);
-
-			// イベントIDベースの重複チェック
-			const eventId = eventBody.event_id;
-			if (eventId) {
-				const duplicateChecker = getDuplicateEventChecker();
-				const wasAlreadyProcessed = await duplicateChecker.markEventAsProcessed(eventId);
-
-				if (wasAlreadyProcessed) {
-					log.debug(`Duplicate event detected (id: ${eventId}), skipping`, { eventId, event });
-					return;
-				}
-			} else {
-				log.warn('Event without event_id received', { event, teamId: args[1].team_id });
-			}
-
-			if (eventBody.team_id === this.#team) {
-				for (const listener of listeners) {
-					try {
-						listener(...args);
-					} catch (error) {
-						log.error(`Error in listener for event "${event}":`, { error });
-					}
-				}
-			}
-
-			for (const listener of allTeamListeners) {
-				try {
-					listener(...args);
-				} catch (error) {
-					log.error(`Error in all-team listener for event "${event}":`, { error });
-				}
+			// args: [body.event, body: {team_id: string}]
+			if (args[1].team_id === this.#team) {
+				listener(...args);
 			}
 		});
-	}
-
-	// listen on events against all teams.
-	onAllTeam(event: string, listener: (...args: any[]) => void): any {
-		if (!this.#allTeamListeners.has(event)) {
-			this.#allTeamListeners.set(event, []);
-		}
-
-		this.#allTeamListeners.get(event)?.push(listener);
-
-		if (!this.#registeredEvents.has(event)) {
-			this.registerEventCallback(event);
-			this.#registeredEvents.add(event);
-		}
-	}
-
-	// listen on events against the team.
-	on(event: string, listener: (...args: any[]) => void): any {
-		if (!this.#listeners.has(event)) {
-			this.#listeners.set(event, []);
-		}
-
-		this.#listeners.get(event)?.push(listener);
-
-		if (!this.#registeredEvents.has(event)) {
-			this.registerEventCallback(event);
-			this.#registeredEvents.add(event);
-		}
 	}
 
 	// feel free to add any other [Events](https://nodejs.org/api/events.html) methods you want!


### PR DESCRIPTION
Fixes #1028.

Regression by #1015.

TeamEventClientクラスは複数のインスタンスが作成されるため、イベント重複除去が複数行われ、除去するべきでないイベントが除去されてしまう不具合が存在した。

EventClientをラップするEventClientWrapperクラスを作成し、TeamEventClientにあったイベント重複除去処理をこちらに実装した。

TeamEventClientは #1015 以前のコードに戻した。

ついでに、DuplicateEventCheckerのRedisとの通信がアトミックでなかったので、SETのNXオプションを用いて単一コマンドで処理するようにした。