### PR TITLE
auto-archiver: conversations.listのページネーションを適切に処理するよう修正

### DIFF
--- a/auto-archiver/index.test.ts
+++ b/auto-archiver/index.test.ts
@@ -1,13 +1,4 @@
-/* eslint-disable import/imports-first */
-/* eslint-disable import/first */
 /* eslint-env jest */
-
-jest.mock('../lib/state');
-jest.mock('../lib/slack');
-jest.mock('../lib/slackUtils');
-jest.mock('node-schedule', () => ({
-	scheduleJob: jest.fn(),
-}));
 
 import {SectionBlock} from '@slack/web-api';
 import {noop} from 'lodash';
@@ -17,6 +8,13 @@ import Slack from '../lib/slackMock';
 import State from '../lib/state';
 import {Deferred} from '../lib/utils';
 import autoArchiver, {ChannelsStateObj, StateObj} from './index';
+
+jest.mock('../lib/state');
+jest.mock('../lib/slack');
+jest.mock('../lib/slackUtils');
+jest.mock('node-schedule', () => ({
+	scheduleJob: jest.fn(),
+}));
 
 describe('auto-archiver', () => {
 	const FAKE_CHANNEL = 'C12345678';

--- a/auto-archiver/index.test.ts
+++ b/auto-archiver/index.test.ts
@@ -27,7 +27,7 @@ describe('auto-archiver', () => {
 	jest.useFakeTimers();
 
 	const registerScheduleCallback = () => {
-		const scheduleMock = schedule as jest.Mocked<typeof schedule>;
+		const scheduleMock = jest.mocked(schedule);
 		const deferred = new Deferred<JobCallback>();
 
 		scheduleMock.scheduleJob.mockImplementationOnce((rule, fn) => {

--- a/auto-archiver/index.ts
+++ b/auto-archiver/index.ts
@@ -115,10 +115,10 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 		log.info(`Fetched ${allChannels.length} channels`);
 
 		for (const channel of allChannels) {
-			log.info(`Checking channel ${channel.id} (${channel.name}) for archiving`);
+			log.debug(`Checking channel ${channel.id} (${channel.name}) for archiving`);
 
 			if (channel.is_archived || channel.is_general || channel.name.startsWith('_')) {
-				log.info(`Skipping channel ${channel.id} (${channel.name}) - already archived or special channel`);
+				log.debug(`Skipping channel ${channel.id} (${channel.name}) - already archived or special channel`);
 				continue;
 			}
 
@@ -126,12 +126,12 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 				snooze.channelId === channel.id &&
 				snooze.expire > now.getTime()
 			))) {
-				log.info(`Skipping channel ${channel.id} (${channel.name}) - snoozed`);
+				log.debug(`Skipping channel ${channel.id} (${channel.name}) - snoozed`);
 				continue;
 			}
 
 			if (channels[channel.id] === undefined) {
-				log.info(`Channel ${channel.id} (${channel.name}) has no messages recorded yet. Skipping`);
+				log.debug(`Channel ${channel.id} (${channel.name}) has no messages recorded yet. Skipping`);
 				continue;
 			}
 
@@ -139,7 +139,7 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 			const lastMessageDate = new Date(parseFloat(lastMessageTs) * 1000);
 			const diff = now.getTime() - lastMessageDate.getTime();
 
-			log.info(`Last message in channel ${channel.id} (${channel.name}) was at ${lastMessageDate.toISOString()}, diff: ${diff}ms`);
+			log.debug(`Last message in channel ${channel.id} (${channel.name}) was at ${lastMessageDate.toISOString()}, diff: ${diff}ms`);
 
 			if (diff > ARCHIVE_LIMIT_DURATION) {
 				log.info(`Channel ${channel.id} (${channel.name}) has not received any messages for more than ${ARCHIVE_LIMIT_DAYS} days`);

--- a/auto-archiver/index.ts
+++ b/auto-archiver/index.ts
@@ -130,6 +130,11 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 				continue;
 			}
 
+			if (channels[channel.id] === undefined) {
+				log.info(`Channel ${channel.id} (${channel.name}) has no messages recorded yet. Skipping`);
+				continue;
+			}
+
 			const lastMessageTs = channels[channel.id] ?? '0';
 			const lastMessageDate = new Date(parseFloat(lastMessageTs) * 1000);
 			const diff = now.getTime() - lastMessageDate.getTime();

--- a/auto-archiver/index.ts
+++ b/auto-archiver/index.ts
@@ -1,4 +1,5 @@
 import {BlockButtonAction, MessageEvent} from '@slack/bolt';
+import type {Channel} from '@slack/web-api/dist/types/response/ConversationsListResponse';
 import {Mutex} from 'async-mutex';
 import {stripIndent} from 'common-tags';
 import schedule from 'node-schedule';
@@ -71,13 +72,18 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 	});
 
 	const postArchiveProposal = async (now: Date) => {
+		log.info(`Checking channels for archiving at ${now.toISOString()}`);
+
 		if (now.getTime() < ARCHIVE_BOT_LOCK_TIME) {
 			return;
 		}
 
+		log.info(`Processing ${state.notices.length} notices`);
 		for (const notice of state.notices) {
 			const noticeTs = parseFloat(notice.ts) * 1000;
 			const expire = noticeTs + ARCHIVE_WAIT_DURATION;
+			log.info(`Checking notice for channel ${notice.channelId}: ${notice.ts}, expire at ${new Date(expire).toISOString()}`);
+
 			if (now.getTime() >= expire) {
 				await slack.chat.postMessage({
 					channel: notice.channelId,
@@ -91,12 +97,28 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 			}
 		}
 
-		const channelsResult = await slack.conversations.list({
-			types: 'public_channel',
-		});
+		log.info('Fetching channels for archiving');
+		const allChannels: Channel[] = [];
+		let cursor: string | null = null;
 
-		for (const channel of channelsResult.channels) {
+		do {
+			const channelsResult = await slack.conversations.list({
+				types: 'public_channel',
+				limit: 1000,
+				...(cursor ? {cursor} : {}),
+			});
+
+			allChannels.push(...channelsResult.channels);
+			cursor = channelsResult.response_metadata?.next_cursor;
+		} while (cursor);
+
+		log.info(`Fetched ${allChannels.length} channels`);
+
+		for (const channel of allChannels) {
+			log.info(`Checking channel ${channel.id} (${channel.name}) for archiving`);
+
 			if (channel.is_archived || channel.is_general || channel.name.startsWith('_')) {
+				log.info(`Skipping channel ${channel.id} (${channel.name}) - already archived or special channel`);
 				continue;
 			}
 
@@ -104,6 +126,7 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 				snooze.channelId === channel.id &&
 				snooze.expire > now.getTime()
 			))) {
+				log.info(`Skipping channel ${channel.id} (${channel.name}) - snoozed`);
 				continue;
 			}
 
@@ -111,7 +134,11 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 			const lastMessageDate = new Date(parseFloat(lastMessageTs) * 1000);
 			const diff = now.getTime() - lastMessageDate.getTime();
 
+			log.info(`Last message in channel ${channel.id} (${channel.name}) was at ${lastMessageDate.toISOString()}, diff: ${diff}ms`);
+
 			if (diff > ARCHIVE_LIMIT_DURATION) {
+				log.info(`Channel ${channel.id} (${channel.name}) has not received any messages for more than ${ARCHIVE_LIMIT_DAYS} days`);
+
 				const message = await slack.chat.postMessage({
 					channel: channel.id,
 					text: ARCHIVE_PROPOSAL_MESSAGE,

--- a/auto-archiver/index.ts
+++ b/auto-archiver/index.ts
@@ -109,7 +109,7 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 			});
 
 			allChannels.push(...channelsResult.channels);
-			cursor = channelsResult.response_metadata?.next_cursor;
+			cursor = channelsResult.response_metadata?.next_cursor ?? null;
 		} while (cursor);
 
 		log.info(`Fetched ${allChannels.length} channels`);
@@ -130,7 +130,9 @@ export default async ({eventClient, webClient: slack, messageClient: slackIntera
 				continue;
 			}
 
-			if (channels[channel.id] === undefined) {
+			// 理論上、チャンネルが作成されてから一度もメッセージが投稿されないこともあるが、
+			// 誤動作を防ぐためにchannelsオブジェクトに存在しないチャンネルはスキップする
+			if (!Object.hasOwn(channels, channel.id)) {
 				log.debug(`Channel ${channel.id} (${channel.name}) has no messages recorded yet. Skipping`);
 				continue;
 			}


### PR DESCRIPTION
Resolves #1027.

ついでによくなさそうな部分を諸々修正。

at channel を投げるBOTを気軽に手元で起動させてはいけない (1敗)