### PR TITLE
achievements: Add delay to allow slack-patron to cache reaction data

### DIFF
--- a/achievements/index_production.ts
+++ b/achievements/index_production.ts
@@ -137,6 +137,11 @@ const unlockKiToOAchievements = async (event: ReactionAddedEvent) => {
 	}
 	kiToOAchievementsCache.add(cacheKey);
 
+	// Add delay here to allow slack-patron to cache the reaction data
+	await new Promise((resolve) => {
+		setTimeout(resolve, 5000);
+	});
+
 	await mutex.runExclusive(async () => {
 		const messageData = await conversationsHistory({
 			channel: event.item.channel,


### PR DESCRIPTION
「最初にリアクションする」実績が達成されない問題がこれで直ってほしいが、果たして