### PR TITLE
context-free: 置き換え部分の存在しないポストの投稿を拒否

### DIFF
--- a/context-free/index.ts
+++ b/context-free/index.ts
@@ -120,6 +120,7 @@ const composePost = async (message: string): Promise<string> => {
 
   let first = true;
   let match = null;
+  let replacementCount = 0;
 
   while ((match = /(?<placeholder>{(?:<(?<phTag>[^{}<>]*)>)?(?<phName>[^{}<>]*)})/.exec(response)) != null) {
     const {placeholder, phTag, phName} = match.groups;
@@ -141,7 +142,14 @@ const composePost = async (message: string): Promise<string> => {
     else {
       response = response.replace(new RegExp(escapeRegExp(placeholder), 'g'), word);
     }
+
+    replacementCount++;
   }
+
+  if (replacementCount === 0) {
+    throw new Error('No placeholders found in the message.');
+  }
+
   return response;
 };
 


### PR DESCRIPTION
1. 単純にBOTの趣旨に反していそうなため
2. 「他人のポスト」などを解除条件とする一部の実績の趣旨が満たされない可能性があるため