### PR TITLE
Update deprecated google-gemini/gemini-cli-action to google-github-actions/run-gemini-cli

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -164,8 +164,8 @@ jobs:
             Common instruction examples: "focus on security", "check performance", "review error handling", "check for breaking changes"
 
             Once you have the information, provide a comprehensive code review by:
-            1. Writing your review to a file: write_file("review.md", "<your detailed review feedback here>")
-            2. Posting the review: gh pr comment $PR_NUMBER --body-file review.md --repo $REPOSITORY
+            1. Writing your review to a file: write_file("/tmp/review.md", "<your detailed review feedback here>")
+            2. Posting the review: gh pr comment $PR_NUMBER --body-file /tmp/review.md --repo $REPOSITORY
 
             Review Areas:
             - **Security**: Authentication, authorization, input validation, data sanitization


### PR DESCRIPTION
## Summary
- Replace deprecated `google-gemini/gemini-cli-action@main` with the official `google-github-actions/run-gemini-cli@v0`
- Update parameter names: `GEMINI_API_KEY` → `gemini_api_key`, `settings_json` → `settings`
- Maintain all existing functionality and behavior for PR reviews

## Changes Made
- Updated action reference in `.github/workflows/gemini-pr-review.yml`
- Updated parameter names to match new action's API
- Updated comment to reflect migration from deprecated action

## Test Plan
- [x] Branch created and pushed successfully
- [ ] PR workflow triggers and runs without errors
- [ ] Gemini PR review functionality works as expected

## Migration Details
The old `google-gemini/gemini-cli-action` has been deprecated in favor of the official Google GitHub Actions version. This migration ensures continued functionality and compatibility with future updates.

🤖 Generated with [Claude Code](https://claude.ai/code)