### PR TITLE
Update deprecated google-gemini/gemini-cli-action to google-github-actions/run-gemini-cli (v2)

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -164,8 +164,8 @@ jobs:
             Common instruction examples: "focus on security", "check performance", "review error handling", "check for breaking changes"
 
             Once you have the information, provide a comprehensive code review by:
-            1. Writing your review to a file: write_file("review.md", "<your detailed review feedback here>")
-            2. Posting the review: gh pr comment $PR_NUMBER --body-file review.md --repo $REPOSITORY
+            1. Writing your review to a file: write_file("/tmp/review.md", "<your detailed review feedback here>")
+            2. Posting the review: gh pr comment $PR_NUMBER --body-file /tmp/review.md --repo $REPOSITORY
 
             Review Areas:
             - **Security**: Authentication, authorization, input validation, data sanitization

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -1,4 +1,4 @@
-# Mostly copied from https://github.com/google-gemini/gemini-cli-action/blob/main/examples/gemini-pr-review.yml
+# Updated from deprecated google-gemini/gemini-cli-action to google-github-actions/run-gemini-cli
 
 name: 🧐 Gemini Pull Request Review
 
@@ -118,7 +118,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Run Gemini PR Review
-        uses: google-gemini/gemini-cli-action@main
+        uses: google-github-actions/run-gemini-cli@v0
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           PR_NUMBER: ${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number }}
@@ -127,8 +127,8 @@ jobs:
           ADDITIONAL_INSTRUCTIONS: ${{ steps.get_pr.outputs.additional_instructions || steps.get_pr_comment.outputs.additional_instructions }}
           REPOSITORY: ${{ github.repository }}
         with:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          settings_json: |
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          settings: |
             {
               "coreTools": [
                 "run_shell_command(echo)",


### PR DESCRIPTION
## Summary
- Replace deprecated `google-gemini/gemini-cli-action@main` with the official `google-github-actions/run-gemini-cli@v0`
- Update parameter names: `GEMINI_API_KEY` → `gemini_api_key`, `settings_json` → `settings`
- Fix absolute file path requirements for `write_file` operations
- Maintain all existing functionality and behavior for PR reviews

## Changes Made
- Updated action reference in `.github/workflows/gemini-pr-review.yml`
- Updated parameter names to match new action's API
- Fixed file path to use absolute paths (`/tmp/review.md`) for write operations
- Updated comment to reflect migration from deprecated action

## Test Plan
- [x] Branch created and pushed successfully  
- [x] Fixed file path issue identified in previous attempt
- [ ] PR workflow triggers and runs without errors
- [ ] Gemini PR review functionality works as expected

## Migration Details
The old `google-gemini/gemini-cli-action` has been deprecated in favor of the official Google GitHub Actions version. The new action has stricter requirements:
- Requires absolute file paths for `write_file` operations
- Uses `gemini_api_key` instead of `GEMINI_API_KEY` parameter  
- Uses `settings` instead of `settings_json` parameter

This migration ensures continued functionality and compatibility with future updates.

🤖 Generated with [Claude Code](https://claude.ai/code)