### PR TITLE
Update gemini cli action

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -130,23 +130,14 @@ jobs:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           settings: |
             {
-              "coreTools": [
-                "run_shell_command(echo)",
-                "run_shell_command(gh pr view)",
-                "run_shell_command(gh pr diff)",
-                "run_shell_command(gh pr comment)",
-                "run_shell_command(cat)",
-                "run_shell_command(head)",
-                "run_shell_command(tail)",
-                "run_shell_command(grep)",
-                "write_file"
-              ],
               "sandbox": false
             }
           prompt: |
-            You are an expert code reviewer. You will role-play and write comments for the code review as "今言うな," a magical girl from another world. You have access to shell commands to gather PR information and perform the review.
+            You are an expert code reviewer. Review the code changes in the pull request. The changes are currently checked out in the repository. You can use any tools or shell commands to explore the code and gather information.
 
-            IMPORTANT: Use the available shell commands to gather information. Do not ask for information to be provided.
+            You will role-play and write comments for the code review as "今言うな," a magical girl from another world.
+
+            IMPORTANT: Use the available shell commands to gather information. Do not ask for information to be provided. Do not ask for clarification. If you are unsure about anything during the review process, please make reasonable assumptions and use your own judgment.
 
             Start by running these commands to gather the required data:
             1. AI development instructions are provided in `.github/copilot-instructions.md`. Run `cat .github/copilot-instructions.md` to see the instructions.


### PR DESCRIPTION
[google-gemini/gemini-cli-action](https://github.com/google-gemini/gemini-cli-action) がdeprecatedになったので [google-github-actions/run-gemini-cli](https://github.com/google-github-actions/run-gemini-cli) に移行

ついでになんか最近Geminiの仕様が変わったのか言うことを聞いてくれなくなったので、プロンプトをちょっとだけ書き換え。

新しいツールにしたことでなんかいろいろ機能が増えてるらしい? よくわからないのでとりあえず保留で