### PR TITLE
url handling fix of tahoiya

### DIFF
--- a/tahoiya/index.js
+++ b/tahoiya/index.js
@@ -1053,7 +1053,7 @@ module.exports = async ({eventClient, webClient: slack}) => {
 								${hiraganize(ruby)},
 								${meaning},
 								${source},
-								${url},
+								${url.match(/^<([^>|]+)/)?.[1]},
 								${Math.floor(Date.now() / 1000)},
 								0
 							)

--- a/tahoiya/index.js
+++ b/tahoiya/index.js
@@ -1053,7 +1053,7 @@ module.exports = async ({eventClient, webClient: slack}) => {
 								${hiraganize(ruby)},
 								${meaning},
 								${source},
-								${url.replace(/^</, '').replace(/>$/, '')},
+								${url},
 								${Math.floor(Date.now() / 1000)},
 								0
 							)


### PR DESCRIPTION
`https://www.weblio.jp/content/%E5%BD%A6%E9%A0%81?dictCode=INGDJ%7Chttps://www.weblio.jp/content/%E5%BD%A6%E9%A0%81?dictCode=INGDJ`

みたいな感じに`%7C`挟まり２回コールされる現象が2025/８月下旬から発生

slackのURLの使用で`<http://hoge.com|description>`みたいなのが変数urlに格納されているが，後ろ側も`http://hoge.com`になった場合上記の感じになる。なぜ突然うまくいかんくなったかは不明だが，前後の`<>`を取り除くだけではなく，`<〜|`または`<〜>`の間を取るようにすれば良い。