### PR TITLE
slow-quizボットを一時的に無効化

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -129,7 +129,7 @@ const productionBots = [
 	'achievement-quiz',
 	'wadokaichin',
 	'wordle-battle',
-	'slow-quiz',
+	// 'slow-quiz',
 	'dicebot',
 	'taimai',
 	'map-guessr',


### PR DESCRIPTION
9月13日23時頃のslackbot再起動以降、slow-quizの状態が11日10時～12日10時のどこかの状態に巻き戻ってしまう現象が発生した。

原因としてはおそらく[Firestoreの1MB制限](https://stackoverflow.com/q/49144258/2864502)に引っかかったものと見られ、解決するには現在レプリケーションとして使っている `slow_quiz_games` をマスターデータにしてstatesにgamesを状態として持たないようにする必要がある。

すぐには直せなさそう、かつ復旧するまでslow-quizボットへの書き込みは無効化されてしまうと思われるので、復旧するまでの間slow-quizボットを無効化しておくことにした。