### PR TITLE
Upgrade Node.js version to v22.19.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 20.18.1
+nodejs 22.19.0
 rust nightly-2022-07-23

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ TSGのSlackで動くSlackbotたち
 
 ### Prerequisites
 
-* Node.js v20
+* Node.js v22.19.0
+
+MacもしくはLinuxでは[asdf](https://asdf-vm.com/)を使用してインストールすることをオススメします。
 
 ### セットアップ
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:coverage": "npm run test -- --coverage"
   },
   "engines": {
-    "node": "^20.18.1"
+    "node": "^22.19.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
サーバー更新に伴い本番環境が Node.js v22 にアップグレードされたため、それにともないドキュメントを更新。ついでにfunctionsのランタイムもnodejs22に変更してみる