### PR TITLE
twenty-questions: プロンプトを改善

### DIFF
--- a/twenty-questions/TwentyQuestions.test.ts
+++ b/twenty-questions/TwentyQuestions.test.ts
@@ -77,6 +77,11 @@ describe('twenty-questions', () => {
 			ts: slack.fakeTimestamp,
 		});
 
+		const postEphemeral = jest.mocked(slack.webClient.chat.postEphemeral);
+		postEphemeral.mockResolvedValueOnce({
+			ok: true,
+		});
+
 		const state = MockedState.mocks.get('twenty-questions');
 		await twentyQuestions.startGame(slack.fakeUser);
 
@@ -85,9 +90,10 @@ describe('twenty-questions', () => {
 		expect(state.currentGame).not.toBe(null);
 		expect(state.currentGame?.status).toBe('active');
 		expect(state.currentGame?.topic).toBe('テスト');
+		expect(state.currentGame?.topicDescription).toBe('テスト');
 
-		// 10回の選択 + 最終選択で11回
-		expect(mockedChatCompletionsCreate).toHaveBeenCalledTimes(11);
+		// 10回の選択 + 最終選択 + 説明文生成で12回
+		expect(mockedChatCompletionsCreate).toHaveBeenCalledTimes(12);
 		expect(mockedGetCandidateWords).toHaveBeenCalledTimes(1);
 
 		expect(mockedPostMessage).toHaveBeenCalledTimes(1);
@@ -103,6 +109,7 @@ describe('twenty-questions', () => {
 		state.currentGame = {
 			id: 'game-1',
 			topic: 'りんご',
+			topicDescription: 'テスト説明',
 			status: 'active',
 			startedAt: Date.now(),
 			finishedAt: null,

--- a/twenty-questions/views/gameLogModal.test.ts
+++ b/twenty-questions/views/gameLogModal.test.ts
@@ -14,6 +14,7 @@ describe('gameLogModal', () => {
 		const game: FinishedGame = {
 			id: 'game-1',
 			topic: 'りんご',
+			topicDescription: 'テスト説明',
 			startedAt: firestore.Timestamp.now(),
 			finishedAt: firestore.Timestamp.now(),
 			players: [],
@@ -25,12 +26,21 @@ describe('gameLogModal', () => {
 		const header = blocks.find((block) => block.type === 'header');
 		expectEquals(header?.type, 'header');
 		expect(header.text.text).toBe('お題: りんご');
+
+		// データシートセクションを確認
+		const dataSheetSection = blocks.find(
+			(block) => block.type === 'section' && 'text' in block && block.text?.text?.includes('【データシート】'),
+		);
+		expect(dataSheetSection).toBeDefined();
+		expectEquals(dataSheetSection?.type, 'section');
+		expect(dataSheetSection.text.text).toContain('テスト説明');
 	});
 
 	it('shows message when no players', () => {
 		const game: FinishedGame = {
 			id: 'game-1',
 			topic: 'りんご',
+			topicDescription: 'テスト説明',
 			startedAt: firestore.Timestamp.now(),
 			finishedAt: firestore.Timestamp.now(),
 			players: [],
@@ -49,6 +59,7 @@ describe('gameLogModal', () => {
 		const game: FinishedGame = {
 			id: 'game-1',
 			topic: 'りんご',
+			topicDescription: 'テスト説明',
 			startedAt: firestore.Timestamp.now(),
 			finishedAt: firestore.Timestamp.now(),
 			players: [
@@ -93,6 +104,7 @@ describe('gameLogModal', () => {
 		const game: FinishedGame = {
 			id: 'game-1',
 			topic: 'りんご',
+			topicDescription: 'テスト説明',
 			startedAt: firestore.Timestamp.now(),
 			finishedAt: firestore.Timestamp.now(),
 			players: [
@@ -127,6 +139,7 @@ describe('gameLogModal', () => {
 		const game: FinishedGame = {
 			id: 'game-1',
 			topic: 'りんご',
+			topicDescription: 'テスト説明',
 			startedAt: firestore.Timestamp.now(),
 			finishedAt: firestore.Timestamp.now(),
 			players: [
@@ -170,6 +183,7 @@ describe('gameLogModal', () => {
 		const game: FinishedGame = {
 			id: 'game-1',
 			topic: 'りんご',
+			topicDescription: 'テスト説明',
 			startedAt: firestore.Timestamp.now(),
 			finishedAt: firestore.Timestamp.now(),
 			players: [
@@ -211,6 +225,7 @@ describe('gameLogModal', () => {
 		const game: FinishedGame = {
 			id: 'game-1',
 			topic: 'りんご',
+			topicDescription: 'テスト説明',
 			startedAt: firestore.Timestamp.now(),
 			finishedAt: firestore.Timestamp.now(),
 			players: [

--- a/twenty-questions/views/gameLogModal.ts
+++ b/twenty-questions/views/gameLogModal.ts
@@ -13,6 +13,13 @@ export default (game: FinishedGame): View => {
 			},
 		},
 		{
+			type: 'section',
+			text: {
+				type: 'mrkdwn',
+				text: `*【データシート】*\n${game.topicDescription}`,
+			},
+		},
+		{
 			type: 'divider',
 		},
 	];

--- a/twenty-questions/views/gameStatusMessage.test.ts
+++ b/twenty-questions/views/gameStatusMessage.test.ts
@@ -31,6 +31,7 @@ describe('gameStatusMessage', () => {
 			currentGame: {
 				id: 'game-1',
 				topic: 'りんご',
+				topicDescription: 'テスト説明',
 				status: 'active',
 				startedAt: Date.now(),
 				finishedAt: null,
@@ -53,6 +54,7 @@ describe('gameStatusMessage', () => {
 			currentGame: {
 				id: 'game-1',
 				topic: 'りんご',
+				topicDescription: 'テスト説明',
 				status: 'finished',
 				startedAt: Date.now(),
 				finishedAt: Date.now(),
@@ -81,6 +83,7 @@ describe('gameStatusMessage', () => {
 			currentGame: {
 				id: 'game-1',
 				topic: 'りんご',
+				topicDescription: 'テスト説明',
 				status: 'active',
 				startedAt: Date.now(),
 				finishedAt: null,
@@ -107,6 +110,7 @@ describe('gameStatusMessage', () => {
 			currentGame: {
 				id: 'game-1',
 				topic: 'りんご',
+				topicDescription: 'テスト説明',
 				status: 'finished',
 				startedAt: Date.now(),
 				finishedAt: Date.now(),
@@ -134,6 +138,7 @@ describe('gameStatusMessage', () => {
 			currentGame: {
 				id: 'game-1',
 				topic: 'りんご',
+				topicDescription: 'テスト説明',
 				status: 'active',
 				startedAt: Date.now(),
 				finishedAt: null,
@@ -181,6 +186,7 @@ describe('gameStatusMessage', () => {
 			currentGame: {
 				id: 'game-1',
 				topic: 'りんご',
+				topicDescription: 'テスト説明',
 				status: 'active',
 				startedAt: Date.now(),
 				finishedAt: null,
@@ -229,6 +235,7 @@ describe('gameStatusMessage', () => {
 			currentGame: {
 				id: 'game-1',
 				topic: 'りんご',
+				topicDescription: 'テスト説明',
 				status: 'active',
 				startedAt: Date.now(),
 				finishedAt: null,
@@ -252,6 +259,7 @@ describe('gameStatusMessage', () => {
 			currentGame: {
 				id: 'game-1',
 				topic: 'りんご',
+				topicDescription: 'テスト説明',
 				status: 'active',
 				startedAt: Date.now(),
 				finishedAt: null,
@@ -284,6 +292,7 @@ describe('gameStatusMessage', () => {
 			currentGame: {
 				id: 'game-1',
 				topic: 'りんご',
+				topicDescription: 'テスト説明',
 				status: 'active',
 				startedAt: Date.now(),
 				finishedAt: null,

--- a/twenty-questions/views/playerModal.test.ts
+++ b/twenty-questions/views/playerModal.test.ts
@@ -13,6 +13,7 @@ describe('playerModal', () => {
 		currentGame: {
 			id: 'game-1',
 			topic: 'テスト',
+			topicDescription: 'テスト説明',
 			status: 'active',
 			startedAt: Date.now(),
 			finishedAt: null,


### PR DESCRIPTION
* 最初にお題についての基本的なデータを説明した文を作成し、質問に回答する際に使用させるように修正
* 「どちらともいえない」という回答を許可
* 広すぎる意味を持つ単語をお題に選択しないようプロンプトを修正