### PR TITLE
クロスワードのSVG寸法計算エラーを修正

### DIFF
--- a/wordhero/render.ts
+++ b/wordhero/render.ts
@@ -2,10 +2,12 @@ import sharp from 'sharp';
 import loadFont from '../lib/loadFont';
 import path from 'path';
 import {max} from 'lodash';
+import fs from 'fs/promises';
+import {stripIndents} from 'common-tags';
 
 const render = async (board: string[], {color = 'black'}: {color: string}) => {
 	const font = await loadFont('Noto Serif JP Bold');
-	const fontPath = board.map((letter, index) => (
+	const letterPaths = board.map((letter, index) => (
 		font.getPath(
 			letter,
 			index % 4 * 100,
@@ -13,27 +15,55 @@ const render = async (board: string[], {color = 'black'}: {color: string}) => {
 			100,
 		).toSVG(2).replace('<path', `<path fill="${color}"`)
 	)).join('');
-	const svg = Buffer.from(`<svg width="400" height="400">${fontPath}</svg>`);
+	const svg = Buffer.from(`<svg width="400" height="400">${letterPaths}</svg>`);
 	const png = await sharp(svg).png().toBuffer();
 	return png;
 };
 
 export default render;
 
-export const renderCrossword = async (board: {letter: string, color: string}[], boardId: string) => {
+interface CellInfo {
+	x: number;
+	y: number;
+	letter: string;
+	color: string;
+}
+
+export const renderCrossword = async (board: ({letter: string | null, color: string} | null)[], boardId: string) => {
 	const font = await loadFont('Noto Serif JP Bold');
-	const fontPath = board.map((cell, index) => (
-		(cell === null || cell.letter === null) ? '' : font.getPath(
+	const cells = board.flatMap<CellInfo>((cell, index) => {
+		if (cell === null || cell.letter === null) {
+			return [];
+		}
+		return [{
+			x: index % 20,
+			y: Math.floor(index / 20),
+			letter: cell.letter,
+			color: cell.color,
+		}];
+	});
+
+	if (cells.length === 0) {
+		return fs.readFile(path.join(__dirname, `${boardId}.png`));
+	}
+
+	const letterPaths = cells.map((cell) => (
+		font.getPath(
 			cell.letter,
-			index % 20 * 100 + 25,
-			Math.floor(index / 20) * 100 + 105,
+			cell.x * 100 + 25,
+			cell.y * 100 + 105,
 			90,
 		).toSVG(2).replace('<path', `<path fill="${cell.color}"`)
-	)).join('');
-	const cells = board.map((cell, index) => (cell === null || cell.letter === null) ? null : {x: index % 20 + 1, y: Math.floor(index / 20) + 1}).filter((cell): cell is {x: number, y: number} => cell !== null);
-	const maxX = cells.length > 0 ? max(cells.map(({x}) => x)) : 1;
-	const maxY = cells.length > 0 ? max(cells.map(({y}) => y)) : 1;
-	const svg = Buffer.from(`<svg width="${maxX * 100 + 30}" height="${maxY * 100 + 30}">${fontPath}</svg>`);
-	const png = await sharp(path.join(__dirname, `${boardId}.png`)).composite([{input: svg, top: 0, left: 0}]).png().toBuffer();
-	return png;
+	));
+	const maxX = max(cells.map(({x}) => x));
+	const maxY = max(cells.map(({y}) => y));
+	const svg = Buffer.from(stripIndents`
+		<svg width="${maxX * 100 + 130}" height="${maxY * 100 + 130}">
+			${letterPaths.join('')}
+		</svg>
+	`);
+	return sharp(path.join(__dirname, `${boardId}.png`))
+		.composite([{input: svg, top: 0, left: 0}])
+		.png()
+		.toBuffer();
 };


### PR DESCRIPTION
## 概要

空または疎なボードをレンダリングする際に、クロスワードレンダラーが無効なSVG寸法を生成し、`svgload_buffer: bad dimensions`エラーが発生する問題を修正しました。

## 変更内容

### 1. 空のボードの処理を改善
- 全ての文字が非表示（nullセル）の場合、SVG合成をスキップして元のボード画像をそのまま返すように修正
- これにより空のSVGバッファを生成する必要がなくなり、エラーを根本的に回避

### 2. コードのリファクタリング
- `flatMap`を使用してnullセルのフィルタリングとセル情報の構築を一度に実行
- `CellInfo`型を定義してコードの可読性を向上
- 座標計算ロジックを簡素化（`index % 20 + 1` → `index % 20`）
- SVG生成部分を`stripIndents`でフォーマット

### 3. 変数名の改善
- `fontPath` → `letterPaths`: より明確な名前に変更
- セル情報を事前に抽出して処理を整理

## 問題

空のボード配列で新しいクロスワードゲームを初期化すると、レンダラーが無効なSVG寸法を計算していました。これにより以下の問題が発生:
- GLib-CRITICALエラー: "cannot register existing type 'GInitable'"
- Sharpエラー: "Input buffer has corrupt header: svgload_buffer: bad dimensions"

## 解決策

空のボードの場合は早期リターンでSVG合成処理をスキップし、元のボード画像をそのまま返すようにしました:

```typescript
const cells = board.flatMap<CellInfo>((cell, index) => {
    if (cell === null || cell.letter === null) {
        return [];
    }
    return [{...}];
});

if (cells.length === 0) {
    return fs.readFile(path.join(__dirname, `${boardId}.png`));
}
```

これにより、無効なSVGを生成する必要がなくなり、エラーが完全に解消されます。

## テスト計画

- [x] Slackからのクロスワードボット初期化をテスト
- [x] GLib-CRITICALエラーが発生しないことを確認
- [x] 空のボードでエラーが発生しないことを確認
- [x] 通常のボードレンダリングが正しく動作することを確認

Fixes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)
