### PR TITLE
Add Google Calendar notification bot

### DIFF
--- a/google-calendar/.eslintrc.json
+++ b/google-calendar/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+    "extends": "@hakatashi/eslint-config/typescript",
+    "rules": {
+        "no-restricted-syntax": "off",
+        "no-use-before-define": "off",
+        "camelcase": "off",
+        "require-atomic-updates": "off",
+        "import/extensions": "off",
+        "import/default": "off",
+        "import/no-named-as-default-member": "off",
+        "import/prefer-default-export": "off",
+        "no-undef-init": "off"
+    }
+}

--- a/google-calendar/GoogleCalendar.ts
+++ b/google-calendar/GoogleCalendar.ts
@@ -1,0 +1,543 @@
+import {randomUUID} from 'crypto';
+import type {BlockAction, ViewSubmitAction} from '@slack/bolt';
+import type {SlackMessageAdapter} from '@slack/interactive-messages';
+import type {WebClient} from '@slack/web-api';
+import {Mutex} from 'async-mutex';
+import {uniq} from 'lodash';
+import {scheduleJob} from 'node-schedule';
+import logger from '../lib/logger';
+import type {SlackInterface} from '../lib/slack';
+import State from '../lib/state';
+import {
+	getCalendarInfo,
+	getServiceAccountEmail,
+	listUpcomingEvents,
+	syncCalendarEvents,
+} from './calendarClient';
+import type {StateObj, Subscription} from './types';
+import addSubscriptionModal from './views/addSubscriptionModal';
+import type {EventMessage} from './views/eventMessages';
+import {
+	dailySummaryMessage,
+	eventAddedMessage,
+	eventBeforeMessage,
+	eventDeletedMessage,
+	eventStartMessage,
+	weeklySummaryMessage,
+} from './views/eventMessages';
+import settingsModal from './views/settingsModal';
+
+const log = logger.child({bot: 'google-calendar'});
+const mutex = new Mutex();
+
+const BOT_USERNAME = '予定通知くん';
+const BOT_ICON_EMOJI = ':blob-sunglasses:';
+
+const getTodayStr = (): string => new Date().toISOString().slice(0, 10);
+
+const getWeekStr = (): string => {
+	const now = new Date();
+	const jan1 = new Date(now.getFullYear(), 0, 1);
+	const weekNumber = Math.ceil(
+		((now.getTime() - jan1.getTime()) / 86400000 + jan1.getDay() + 1) / 7,
+	);
+	return `${now.getFullYear()}-W${weekNumber.toString().padStart(2, '0')}`;
+};
+
+const isGoneError = (error: unknown): boolean => {
+	if (error instanceof Error && error.message.includes('410')) {
+		return true;
+	}
+	const errObj = error as {code?: number; status?: number};
+	return errObj?.code === 410 || errObj?.status === 410;
+};
+
+interface ChannelMetadata {
+	channelId: string;
+}
+
+export class GoogleCalendar {
+	readonly #slack: WebClient;
+
+	readonly #interactions: SlackMessageAdapter;
+
+	#state: StateObj;
+
+	static async create(slack: SlackInterface): Promise<GoogleCalendar> {
+		log.info('Creating Google Calendar bot instance');
+		const state = await State.init<StateObj>('google-calendar', {
+			subscriptions: [],
+			syncTokens: {},
+			sentNotifications: [],
+			lastDailySummary: {},
+			lastWeeklySummary: {},
+		});
+		log.debug(`Loaded state with ${state.subscriptions.length} subscription(s)`);
+		return new GoogleCalendar(slack, state);
+	}
+
+	constructor(slack: SlackInterface, state: StateObj) {
+		this.#slack = slack.webClient;
+		this.#interactions = slack.messageClient;
+		this.#state = state;
+
+		this.#interactions.action(
+			{type: 'button', actionId: 'gcal_delete_subscription'},
+			(payload: BlockAction) => {
+				log.debug('gcal_delete_subscription action received');
+				mutex.runExclusive(() => this.#handleDeleteSubscription(payload));
+			},
+		);
+
+		this.#interactions.action(
+			{type: 'button', actionId: 'gcal_show_add_subscription'},
+			(payload: BlockAction) => {
+				log.debug('gcal_show_add_subscription action received');
+				mutex.runExclusive(() => this.#handleShowAddSubscription(payload));
+			},
+		);
+
+		this.#interactions.viewSubmission('gcal_add_subscription', (payload: ViewSubmitAction) => {
+			log.debug('gcal_add_subscription view submission received');
+			return mutex.runExclusive(() => this.#handleAddSubscriptionSubmit(payload));
+		});
+	}
+
+	initialize() {
+		log.info('Initializing Google Calendar bot schedules');
+
+		scheduleJob('*/5 * * * *', () => {
+			log.debug('Calendar change poll triggered');
+			mutex.runExclusive(() => this.pollCalendarChanges());
+		});
+
+		scheduleJob('* * * * *', () => {
+			log.debug('Upcoming notification check triggered');
+			mutex.runExclusive(() => this.checkUpcomingNotifications());
+		});
+
+		scheduleJob('0 * * * *', () => {
+			log.debug('Scheduled summary check triggered');
+			mutex.runExclusive(() => this.checkScheduledSummaries());
+		});
+	}
+
+	async showSettingsModal(channelId: string, triggerId: string) {
+		log.debug(`Opening settings modal for channel ${channelId}`);
+		const subs = this.#state.subscriptions.filter((s) => s.channelId === channelId);
+		log.debug(`Found ${subs.length} subscription(s) for channel ${channelId}`);
+		await this.#slack.views.open({
+			trigger_id: triggerId,
+			view: settingsModal(subs, channelId),
+		});
+	}
+
+	async #handleDeleteSubscription(payload: BlockAction) {
+		const action = payload.actions.find((a) => a.action_id === 'gcal_delete_subscription');
+		if (!action || action.type !== 'button' || !payload.view) {
+			return;
+		}
+
+		const subscriptionId = action.value;
+		const metadata = this.#parseMetadata(payload.view?.private_metadata);
+		if (!metadata) {
+			log.debug('Delete subscription: could not parse metadata');
+			return;
+		}
+
+		log.info(`Deleting subscription ${subscriptionId} from channel ${metadata.channelId}`);
+
+		const idx = this.#state.subscriptions.findIndex((s) => s.id === subscriptionId);
+		if (idx === -1) {
+			log.debug(`Subscription ${subscriptionId} not found`);
+		} else {
+			this.#state.subscriptions.splice(idx, 1);
+			log.debug(`Subscription ${subscriptionId} removed`);
+		}
+
+		const subs = this.#state.subscriptions.filter(
+			(s) => s.channelId === metadata.channelId,
+		);
+		await this.#slack.views.update({
+			view_id: payload.view.id,
+			view: settingsModal(subs, metadata.channelId),
+		});
+		log.debug('Settings modal updated after deletion');
+	}
+
+	async #handleShowAddSubscription(payload: BlockAction) {
+		const metadata = this.#parseMetadata(payload.view?.private_metadata);
+		if (!metadata) {
+			log.debug('Show add subscription: could not parse metadata');
+			return;
+		}
+
+		log.debug(`Pushing add subscription modal for channel ${metadata.channelId}`);
+		await this.#slack.views.push({
+			trigger_id: payload.trigger_id,
+			view: addSubscriptionModal(metadata.channelId),
+		});
+	}
+
+	async #handleAddSubscriptionSubmit(payload: ViewSubmitAction) {
+		const metadata = this.#parseMetadata(payload.view.private_metadata);
+		if (!metadata) {
+			log.debug('Add subscription submit: could not parse metadata');
+			return undefined;
+		}
+
+		const values = payload.view.state?.values ?? {};
+
+		const calendarId =
+			(values.calendar_id_block?.calendar_id as {value?: string} | undefined)?.value?.trim() ?? '';
+
+		const selectedOptions =
+			(values.notifications_block?.notifications as {selected_options?: {value: string}[]} | undefined)
+				?.selected_options ?? [];
+		const onAddDelete = selectedOptions.some((o) => o.value === 'on_add_delete');
+		const onStart = selectedOptions.some((o) => o.value === 'on_start');
+
+		const minutesBeforeRaw =
+			(values.minutes_before_block?.minutes_before as {value?: string} | undefined)?.value;
+		const minutesBefore = minutesBeforeRaw ? parseInt(minutesBeforeRaw) : null;
+
+		const dailyHourRaw =
+			(values.daily_hour_block?.daily_hour as {selected_option?: {value: string}} | undefined)
+				?.selected_option?.value;
+		const dailyHour = dailyHourRaw === undefined ? null : parseInt(dailyHourRaw);
+
+		const weeklyDayRaw =
+			(values.weekly_day_block?.weekly_day as {selected_option?: {value: string}} | undefined)
+				?.selected_option?.value;
+		const weeklyDay = weeklyDayRaw === undefined ? null : parseInt(weeklyDayRaw);
+
+		const weeklyHourRaw =
+			(values.weekly_hour_block?.weekly_hour as {selected_option?: {value: string}} | undefined)
+				?.selected_option?.value;
+		const weeklyHour = weeklyHourRaw === undefined ? null : parseInt(weeklyHourRaw);
+
+		log.debug(`Add subscription submit: calendarId=${calendarId}, channel=${metadata.channelId}`);
+
+		if (!calendarId) {
+			log.debug('Add subscription submit: empty calendarId');
+			return {
+				response_action: 'errors' as const,
+				errors: {calendar_id_block: 'カレンダーIDを入力してください。'},
+			};
+		}
+
+		if ((weeklyDay === null) !== (weeklyHour === null)) {
+			log.debug('Add subscription submit: weekly day/hour mismatch');
+			return {
+				response_action: 'errors' as const,
+				errors: {
+					weekly_day_block:
+						'毎週サマリーを設定する場合は、曜日と時刻の両方を選択してください。',
+				},
+			};
+		}
+
+		log.debug(`Fetching calendar info for ${calendarId}`);
+		let calendarName = '';
+		try {
+			const info = await getCalendarInfo(calendarId);
+			calendarName = info.summary;
+			log.debug(`Calendar info fetched: name="${calendarName}"`);
+		} catch (error: unknown) {
+			const serviceAccountEmail = getServiceAccountEmail();
+			const errMsg = error instanceof Error ? error.message : String(error);
+			log.debug(`Calendar access failed for ${calendarId}: ${errMsg}`);
+
+			const isAccessDenied =
+				errMsg.includes('403') ||
+				errMsg.includes('notFound') ||
+				errMsg.includes('404') ||
+				errMsg.includes('insufficientPermissions');
+
+			const hint = isAccessDenied
+				? `このカレンダーへのアクセス権がありません。カレンダーの「設定と共有」→「特定のユーザーとの共有」に以下のサービスアカウントを追加してください: ${serviceAccountEmail}`
+				: `カレンダーへのアクセスに失敗しました。カレンダーの「設定と共有」→「特定のユーザーとの共有」に以下のサービスアカウントを追加してください: ${serviceAccountEmail} (error: ${errMsg})`;
+
+			return {
+				response_action: 'errors' as const,
+				errors: {calendar_id_block: hint},
+			};
+		}
+
+		const subscription: Subscription = {
+			id: randomUUID(),
+			channelId: metadata.channelId,
+			calendarId,
+			calendarName,
+			onAddDelete,
+			onStart,
+			minutesBefore: minutesBefore === null || isNaN(minutesBefore) ? null : minutesBefore,
+			dailyHour: dailyHour === null || isNaN(dailyHour) ? null : dailyHour,
+			weeklyDay: weeklyDay === null || isNaN(weeklyDay) ? null : weeklyDay,
+			weeklyHour: weeklyHour === null || isNaN(weeklyHour) ? null : weeklyHour,
+		};
+
+		log.info(
+			`Adding subscription for calendar "${calendarName}" (${calendarId}) to channel ${metadata.channelId}`,
+		);
+		this.#state.subscriptions.push(subscription);
+
+		const rootViewId = (payload.view as {root_view_id?: string}).root_view_id;
+		if (rootViewId && rootViewId !== payload.view.id) {
+			log.debug(`Updating parent settings modal (viewId=${rootViewId})`);
+			const subs = this.#state.subscriptions.filter(
+				(s) => s.channelId === metadata.channelId,
+			);
+			await this.#slack.views.update({
+				view_id: rootViewId,
+				view: settingsModal(subs, metadata.channelId),
+			});
+		}
+
+		return undefined;
+	}
+
+	async pollCalendarChanges() {
+		const calendarIds = uniq(this.#state.subscriptions.map((s) => s.calendarId));
+		log.debug(`Polling changes for ${calendarIds.length} calendar(s)`);
+
+		for (const calendarId of calendarIds) {
+			const previousSyncToken = this.#state.syncTokens[calendarId] ?? null;
+			log.debug(
+				`Syncing calendar ${calendarId} (syncToken=${previousSyncToken === null ? 'none' : 'present'})`,
+			);
+
+			try {
+				const {events, nextSyncToken} = await syncCalendarEvents(
+					calendarId,
+					previousSyncToken,
+				);
+
+				this.#state.syncTokens[calendarId] = nextSyncToken;
+				log.debug(`Synced calendar ${calendarId}: ${events.length} event(s) in delta`);
+
+				if (previousSyncToken === null) {
+					log.debug(`Initial sync for ${calendarId}, skipping notifications`);
+					continue;
+				}
+
+				const addDeleteSubs = this.#state.subscriptions.filter(
+					(s) => s.calendarId === calendarId && s.onAddDelete,
+				);
+
+				for (const event of events) {
+					const isDeleted = event.status === 'cancelled';
+					log.debug(
+						`Event change: "${event.summary}" status=${event.status} → notifying ${addDeleteSubs.length} subscription(s)`,
+					);
+					const message = isDeleted ? eventDeletedMessage(event) : eventAddedMessage(event);
+
+					for (const sub of addDeleteSubs) {
+						await this.#postMessage(sub.channelId, message);
+					}
+				}
+			} catch (error) {
+				if (isGoneError(error)) {
+					log.warn(
+						`Sync token expired for calendar ${calendarId}, will perform full resync`,
+					);
+					delete this.#state.syncTokens[calendarId];
+				} else {
+					log.error(`Failed to sync calendar ${calendarId}`, {error});
+				}
+			}
+		}
+	}
+
+	async checkUpcomingNotifications() {
+		const now = new Date();
+		const cutoff = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+
+		const prevCount = this.#state.sentNotifications.length;
+		this.#state.sentNotifications = this.#state.sentNotifications.filter((key) => {
+			const [, , , dateStr] = key.split(':');
+			return dateStr !== undefined && new Date(dateStr) > cutoff;
+		});
+		const pruned = prevCount - this.#state.sentNotifications.length;
+		if (pruned > 0) {
+			log.debug(`Pruned ${pruned} stale sent-notification key(s)`);
+		}
+
+		const relevantSubs = this.#state.subscriptions.filter(
+			(s) => s.onStart || s.minutesBefore !== null,
+		);
+
+		if (relevantSubs.length === 0) {
+			log.debug('No subscriptions with upcoming notification settings, skipping');
+			return;
+		}
+
+		const calendarIds = uniq(relevantSubs.map((s) => s.calendarId));
+		log.debug(`Checking upcoming notifications for ${calendarIds.length} calendar(s)`);
+
+		for (const calendarId of calendarIds) {
+			const calendarSubs = relevantSubs.filter((s) => s.calendarId === calendarId);
+			const maxLookahead = Math.max(
+				...calendarSubs.map((s) => (s.minutesBefore ?? 0)),
+				1,
+			);
+
+			const windowEnd = new Date(now.getTime() + (maxLookahead + 2) * 60 * 1000);
+			log.debug(
+				`Fetching events for ${calendarId} in window [now, +${maxLookahead + 2}min]`,
+			);
+
+			try {
+				const events = await listUpcomingEvents(calendarId, now, windowEnd);
+				log.debug(`Found ${events.length} upcoming event(s) for ${calendarId}`);
+
+				for (const event of events) {
+					if (!event.start?.dateTime || !event.id) {
+						continue;
+					}
+
+					const startTime = new Date(event.start.dateTime);
+					const minutesUntilStart = (startTime.getTime() - now.getTime()) / 60000;
+
+					for (const sub of calendarSubs) {
+						if (sub.onStart && minutesUntilStart >= 0 && minutesUntilStart < 1) {
+							const key = `${sub.id}:start:${event.id}:${getTodayStr()}`;
+							if (this.#state.sentNotifications.includes(key)) {
+								log.debug(
+									`Start notification already sent for event "${event.summary}" (key=${key})`,
+								);
+							} else {
+								log.info(
+									`Sending start notification for event "${event.summary}" to channel ${sub.channelId}`,
+								);
+								this.#state.sentNotifications.push(key);
+								await this.#postMessage(sub.channelId, eventStartMessage(event));
+							}
+						}
+
+						if (sub.minutesBefore !== null) {
+							const diff = Math.abs(minutesUntilStart - sub.minutesBefore);
+							if (diff < 1) {
+								const key = `${sub.id}:before:${event.id}:${getTodayStr()}`;
+								if (this.#state.sentNotifications.includes(key)) {
+									log.debug(
+										`Before notification already sent for event "${event.summary}" (key=${key})`,
+									);
+								} else {
+									log.info(
+										`Sending ${sub.minutesBefore}min-before notification for event "${event.summary}" to channel ${sub.channelId}`,
+									);
+									this.#state.sentNotifications.push(key);
+									await this.#postMessage(
+										sub.channelId,
+										eventBeforeMessage(event, sub.minutesBefore),
+									);
+								}
+							}
+						}
+					}
+				}
+			} catch (error) {
+				log.error(`Failed to list upcoming events for calendar ${calendarId}`, {error});
+			}
+		}
+	}
+
+	async checkScheduledSummaries() {
+		const now = new Date();
+		const currentHour = now.getHours();
+		const currentDay = now.getDay();
+		const today = getTodayStr();
+		const thisWeek = getWeekStr();
+
+		log.debug(
+			`Checking scheduled summaries: hour=${currentHour}, day=${currentDay}, date=${today}, week=${thisWeek}`,
+		);
+
+		for (const sub of this.#state.subscriptions) {
+			if (sub.dailyHour !== null && sub.dailyHour === currentHour) {
+				if (this.#state.lastDailySummary[sub.id] === today) {
+					log.debug(`Daily summary already sent today for subscription ${sub.id}`);
+				} else {
+					log.info(
+						`Sending daily summary for subscription ${sub.id} (calendar: ${sub.calendarName})`,
+					);
+					try {
+						const timeMax = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+						const events = await listUpcomingEvents(sub.calendarId, now, timeMax);
+						log.debug(`Daily summary: ${events.length} event(s) found`);
+						if (events.length > 0) {
+							await this.#postMessage(sub.channelId, dailySummaryMessage(events, now));
+						} else {
+							log.debug('Daily summary: no events, skipping post');
+						}
+						this.#state.lastDailySummary[sub.id] = today;
+					} catch (error) {
+						log.error(
+							`Failed to send daily summary for subscription ${sub.id}`,
+							{error},
+						);
+					}
+				}
+			}
+
+			if (
+				sub.weeklyDay !== null &&
+				sub.weeklyHour !== null &&
+				sub.weeklyDay === currentDay &&
+				sub.weeklyHour === currentHour
+			) {
+				if (this.#state.lastWeeklySummary[sub.id] === thisWeek) {
+					log.debug(`Weekly summary already sent this week for subscription ${sub.id}`);
+				} else {
+					log.info(
+						`Sending weekly summary for subscription ${sub.id} (calendar: ${sub.calendarName})`,
+					);
+					try {
+						const timeMax = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+						const events = await listUpcomingEvents(sub.calendarId, now, timeMax);
+						log.debug(`Weekly summary: ${events.length} event(s) found`);
+						if (events.length > 0) {
+							await this.#postMessage(sub.channelId, weeklySummaryMessage(events, now));
+						} else {
+							log.debug('Weekly summary: no events, skipping post');
+						}
+						this.#state.lastWeeklySummary[sub.id] = thisWeek;
+					} catch (error) {
+						log.error(
+							`Failed to send weekly summary for subscription ${sub.id}`,
+							{error},
+						);
+					}
+				}
+			}
+		}
+	}
+
+	#parseMetadata(raw: string | null | undefined): ChannelMetadata | null {
+		if (!raw) {
+			return null;
+		}
+		try {
+			const parsed = JSON.parse(raw) as Partial<ChannelMetadata>;
+			if (!parsed.channelId) {
+				return null;
+			}
+			return {channelId: parsed.channelId};
+		} catch {
+			return null;
+		}
+	}
+
+	#postMessage(channelId: string, message: EventMessage) {
+		log.debug(`Posting message to channel ${channelId}: "${message.text}"`);
+		return this.#slack.chat.postMessage({
+			channel: channelId,
+			username: BOT_USERNAME,
+			icon_emoji: BOT_ICON_EMOJI,
+			unfurl_links: false,
+			unfurl_media: false,
+			...message,
+		});
+	}
+}

--- a/google-calendar/calendarClient.ts
+++ b/google-calendar/calendarClient.ts
@@ -97,8 +97,6 @@ export const listUpcomingEvents = async (
 		nextPageToken = response.data.nextPageToken ?? undefined;
 	} while (nextPageToken);
 
-	console.log(allEvents);
-
 	// Exclude events matching all of the following conditions:
 	// - starts at 0:00 and ends at 0:00
 	// - starts after 24 hours before timeMax

--- a/google-calendar/calendarClient.ts
+++ b/google-calendar/calendarClient.ts
@@ -1,0 +1,134 @@
+import {readFileSync} from 'fs';
+import {google, calendar_v3} from 'googleapis';
+import dayjs from '../lib/dayjs';
+import type {CalendarEvent} from './types';
+
+let calendarInstance: calendar_v3.Calendar | null = null;
+
+const getCalendar = (): calendar_v3.Calendar => {
+	if (calendarInstance === null) {
+		const auth = new google.auth.GoogleAuth({
+			scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+		});
+		calendarInstance = google.calendar({version: 'v3', auth});
+	}
+	return calendarInstance;
+};
+
+export const getServiceAccountEmail = (): string => {
+	const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+	if (!credPath) {
+		return '';
+	}
+	try {
+		const creds = JSON.parse(readFileSync(credPath, 'utf8')) as {client_email?: string};
+		return creds.client_email ?? '';
+	} catch {
+		return '';
+	}
+};
+
+export interface CalendarInfo {
+	summary: string;
+}
+
+export const getCalendarInfo = async (calendarId: string): Promise<CalendarInfo> => {
+	const response = await getCalendar().calendars.get({calendarId});
+	return {summary: response.data.summary ?? calendarId};
+};
+
+export interface SyncResult {
+	events: CalendarEvent[];
+	nextSyncToken: string;
+}
+
+export const syncCalendarEvents = async (
+	calendarId: string,
+	syncToken: string | null,
+): Promise<SyncResult> => {
+	const calendar = getCalendar();
+	const allEvents: CalendarEvent[] = [];
+	let nextPageToken: string | undefined = undefined;
+	let nextSyncToken = '';
+
+	const baseParams: calendar_v3.Params$Resource$Events$List = {
+		calendarId,
+		showDeleted: true,
+		singleEvents: true,
+		...(syncToken
+			? {syncToken}
+			: {timeMin: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()}),
+	};
+
+	do {
+		const response = await calendar.events.list({
+			...baseParams,
+			...(nextPageToken ? {pageToken: nextPageToken} : {}),
+		});
+		allEvents.push(...(response.data.items ?? []));
+		nextPageToken = response.data.nextPageToken ?? undefined;
+		if (response.data.nextSyncToken) {
+			nextSyncToken = response.data.nextSyncToken;
+		}
+	} while (nextPageToken);
+
+	return {events: allEvents, nextSyncToken};
+};
+
+export const listUpcomingEvents = async (
+	calendarId: string,
+	timeMin: Date,
+	timeMax: Date,
+): Promise<CalendarEvent[]> => {
+	const calendar = getCalendar();
+	const allEvents: CalendarEvent[] = [];
+	let nextPageToken: string | undefined = undefined;
+
+	do {
+		const response = await calendar.events.list({
+			calendarId,
+			timeMin: timeMin.toISOString(),
+			timeMax: timeMax.toISOString(),
+			singleEvents: true,
+			orderBy: 'startTime',
+			...(nextPageToken ? {pageToken: nextPageToken} : {}),
+		});
+		allEvents.push(...(response.data.items ?? []));
+		nextPageToken = response.data.nextPageToken ?? undefined;
+	} while (nextPageToken);
+
+	console.log(allEvents);
+
+	// Exclude events matching all of the following conditions:
+	// - starts at 0:00 and ends at 0:00
+	// - starts after 24 hours before timeMax
+	const filteredEvents = allEvents.filter((event) => {
+		// Events with dateTime
+		if (event.start?.dateTime && event.end?.dateTime) {
+			const startDateTime = dayjs(event.start.dateTime).tz('Asia/Tokyo');
+			const endDateTime = dayjs(event.end.dateTime).tz('Asia/Tokyo');
+			if (
+				startDateTime.hour() === 0 &&
+				startDateTime.minute() === 0 &&
+				endDateTime.hour() === 0 &&
+				endDateTime.minute() === 0 &&
+				startDateTime.isAfter(timeMax.getTime() - 24 * 60 * 60 * 1000)
+			) {
+				return false;
+			}
+		}
+
+		// All-day events
+		if (event.start?.date && event.end?.date && !event.start.dateTime && !event.end.dateTime) {
+			const startDate = dayjs(event.start.date).tz('Asia/Tokyo');
+			if (
+				startDate.isAfter(timeMax.getTime() - 24 * 60 * 60 * 1000)
+			) {
+				return false;
+			}
+		}
+		return true;
+	});
+
+	return filteredEvents;
+};

--- a/google-calendar/index.ts
+++ b/google-calendar/index.ts
@@ -1,0 +1,31 @@
+import {Mutex} from 'async-mutex';
+import type {FastifyPluginCallback} from 'fastify';
+import plugin from 'fastify-plugin';
+import type {SlashCommandEndpoint, SlackInterface} from '../lib/slack';
+import {GoogleCalendar} from './GoogleCalendar';
+
+const mutex = new Mutex();
+
+export const server = (slack: SlackInterface) => {
+	const callback: FastifyPluginCallback = async (fastify, _opts, next) => {
+		const bot = await GoogleCalendar.create(slack);
+		bot.initialize();
+
+		fastify.post<SlashCommandEndpoint>('/slash/calendar', (req, res) => {
+			if (req.body.token !== process.env.SLACK_VERIFICATION_TOKEN) {
+				res.code(400);
+				return 'Bad Request';
+			}
+
+			mutex.runExclusive(async () => {
+				await bot.showSettingsModal(req.body.channel_id, req.body.trigger_id);
+			});
+
+			return '';
+		});
+
+		next();
+	};
+
+	return plugin(callback);
+};

--- a/google-calendar/types.ts
+++ b/google-calendar/types.ts
@@ -1,0 +1,24 @@
+import type {calendar_v3} from 'googleapis';
+
+export type CalendarEvent = calendar_v3.Schema$Event;
+
+export interface Subscription {
+	id: string;
+	channelId: string;
+	calendarId: string;
+	calendarName: string;
+	onAddDelete: boolean;
+	onStart: boolean;
+	minutesBefore: number | null;
+	dailyHour: number | null;
+	weeklyDay: number | null;
+	weeklyHour: number | null;
+}
+
+export interface StateObj {
+	subscriptions: Subscription[];
+	syncTokens: {[calendarId: string]: string};
+	sentNotifications: string[];
+	lastDailySummary: {[subscriptionId: string]: string};
+	lastWeeklySummary: {[subscriptionId: string]: string};
+}

--- a/google-calendar/views/addSubscriptionModal.ts
+++ b/google-calendar/views/addSubscriptionModal.ts
@@ -1,0 +1,129 @@
+import type {View} from '@slack/web-api';
+
+const DAY_OPTIONS = [
+	{text: {type: 'plain_text' as const, text: '日曜日'}, value: '0'},
+	{text: {type: 'plain_text' as const, text: '月曜日'}, value: '1'},
+	{text: {type: 'plain_text' as const, text: '火曜日'}, value: '2'},
+	{text: {type: 'plain_text' as const, text: '水曜日'}, value: '3'},
+	{text: {type: 'plain_text' as const, text: '木曜日'}, value: '4'},
+	{text: {type: 'plain_text' as const, text: '金曜日'}, value: '5'},
+	{text: {type: 'plain_text' as const, text: '土曜日'}, value: '6'},
+];
+
+const HOUR_OPTIONS = Array.from({length: 24}, (_, i) => ({
+	text: {type: 'plain_text' as const, text: `${i}時`},
+	value: i.toString(),
+}));
+
+export default (channelId: string): View => ({
+	type: 'modal',
+	callback_id: 'gcal_add_subscription',
+	title: {type: 'plain_text', text: '通知を追加'},
+	submit: {type: 'plain_text', text: '追加'},
+	close: {type: 'plain_text', text: 'キャンセル'},
+	private_metadata: JSON.stringify({channelId}),
+	blocks: [
+		{
+			type: 'input',
+			block_id: 'calendar_id_block',
+			element: {
+				type: 'plain_text_input',
+				action_id: 'calendar_id',
+				placeholder: {
+					type: 'plain_text',
+					text: 'xxxxxxxxxx@group.calendar.google.com',
+				},
+			},
+			label: {type: 'plain_text', text: 'カレンダーID'},
+			hint: {
+				type: 'plain_text',
+				text: 'Google CalendarのカレンダーIDを入力してください。カレンダーの設定ページ > 「カレンダーの統合」で確認できます。',
+			},
+		},
+		{
+			type: 'input',
+			block_id: 'notifications_block',
+			optional: true,
+			element: {
+				type: 'checkboxes',
+				action_id: 'notifications',
+				options: [
+					{
+						text: {type: 'mrkdwn', text: '＊イベント追加/更新/削除＊に通知する'},
+						value: 'on_add_delete',
+					},
+					{
+						text: {type: 'mrkdwn', text: '＊イベント開始時＊に通知する'},
+						value: 'on_start',
+					},
+				],
+			},
+			label: {type: 'plain_text', text: '通知のタイプ'},
+		},
+		{
+			type: 'input',
+			block_id: 'minutes_before_block',
+			optional: true,
+			element: {
+				type: 'number_input',
+				action_id: 'minutes_before',
+				is_decimal_allowed: false,
+				min_value: '1',
+				max_value: '1440',
+				placeholder: {type: 'plain_text', text: '例: 30'},
+			},
+			label: {type: 'plain_text', text: 'N分前通知'},
+			hint: {
+				type: 'plain_text',
+				text: 'イベント開始のN分前に通知を送ります。空白の場合は無効です。',
+			},
+		},
+		{
+			type: 'input',
+			block_id: 'daily_hour_block',
+			optional: true,
+			element: {
+				type: 'static_select',
+				action_id: 'daily_hour',
+				placeholder: {type: 'plain_text', text: '時刻を選択...'},
+				options: HOUR_OPTIONS,
+			},
+			label: {type: 'plain_text', text: '毎日のサマリー時刻'},
+			hint: {
+				type: 'plain_text',
+				text: '24時間以内に開始されるイベントと、現在開催中のイベントの一覧を毎日この時刻に投稿します。イベントがない場合は投稿しません。',
+			},
+		},
+		{
+			type: 'section',
+			text: {
+				type: 'mrkdwn',
+				text: '*毎週のサマリー*\n7日以内に開始されるイベントの一覧を毎週特定の曜日・時刻に投稿します。イベントがない場合は投稿しません。曜日と時刻は両方設定してください。',
+			},
+		},
+		{
+			type: 'input',
+			block_id: 'weekly_day_block',
+			optional: true,
+			element: {
+				type: 'static_select',
+				action_id: 'weekly_day',
+				placeholder: {type: 'plain_text', text: '曜日を選択...'},
+				options: DAY_OPTIONS,
+			},
+			label: {type: 'plain_text', text: '毎週サマリー: 曜日'},
+		},
+		{
+			type: 'input',
+			block_id: 'weekly_hour_block',
+			optional: true,
+			element: {
+				type: 'static_select',
+				action_id: 'weekly_hour',
+				placeholder: {type: 'plain_text', text: '時刻を選択...'},
+				options: HOUR_OPTIONS,
+			},
+			label: {type: 'plain_text', text: '毎週サマリー: 時刻'},
+		},
+	],
+});

--- a/google-calendar/views/eventMessages.ts
+++ b/google-calendar/views/eventMessages.ts
@@ -1,0 +1,301 @@
+import type {KnownBlock, SectionBlock} from '@slack/bolt';
+import dayjs from '../../lib/dayjs';
+import type {CalendarEvent} from '../types';
+
+const incrementDate = (dateString: string, count: number) => {
+	const date = new Date(dateString);
+	date.setDate(date.getDate() + count);
+	return date.toISOString().slice(0, 10);
+};
+
+const formatEventTime = (event: CalendarEvent, includeDate: boolean): string => {
+	if (event.start?.dateTime) {
+		const startTs = Math.floor(new Date(event.start.dateTime).getTime() / 1000);
+		if (event.end?.dateTime) {
+			const endTs = Math.floor(new Date(event.end.dateTime).getTime() / 1000);
+			return `<!date^${startTs}^${includeDate ? '{date_short_pretty} {time}' : '{time}'}|${event.start.dateTime}> 〜 <!date^${endTs}^{time}|${event.end.dateTime}>`;
+		}
+		return `<!date^${startTs}^${includeDate ? '{date_short_pretty} {time}' : '{time}'}|${event.start.dateTime}>`;
+	}
+	if (event.start?.date && event.end?.date) {
+		const startDate = dayjs(event.start.date).tz('Asia/Tokyo').format('M月D日');
+		const endDate = dayjs(event.end.date).tz('Asia/Tokyo').add(-1, 'day').format('M月D日');
+		return `${startDate} 〜 ${endDate}`;
+	}
+	if (event.start?.date) {
+		const startDate = dayjs(event.start.date).tz('Asia/Tokyo').format('M月D日');
+		return `${startDate} (終日)`;
+	}
+	return '(日時未設定)';
+};
+
+const buildEventDetailBlocks = (event: CalendarEvent): KnownBlock[] => {
+	const blocks: KnownBlock[] = [];
+
+	let placeUrl: string | null = null;
+	const isLocationUrl = event.location?.startsWith('http://') || event.location?.startsWith('https://');
+	if (isLocationUrl) {
+		placeUrl = event.location!;
+	} else if (event.location) {
+		const encodedLocation = encodeURIComponent(event.location);
+		placeUrl = `https://www.google.com/maps/search/?api=1&query=${encodedLocation}`;
+	}
+
+	const normalizedDescription = event.description?.replaceAll('<br>', '\n') ?? '';
+	const hasMore = normalizedDescription.length > 199;
+	const description = hasMore ? `${normalizedDescription.slice(0, 199)}⋯` : normalizedDescription;
+
+	let subtitle = formatEventTime(event, true);
+	if (event.location) {
+		subtitle += ` / ${event.location}`;
+	}
+	if (subtitle.length > 149) {
+		subtitle = `${subtitle.slice(0, 149)}⋯`;
+	}
+
+	blocks.push({
+		type: 'card',
+		title: {
+			type: 'mrkdwn',
+			text: event.summary ?? '(タイトルなし)',
+			verbatim: false,
+		},
+		subtitle: {
+			type: 'mrkdwn',
+			text: subtitle,
+			verbatim: false,
+		},
+		body: {
+			type: 'mrkdwn',
+			text: description,
+			verbatim: false,
+		},
+		actions: [
+			...(placeUrl ? [
+				{
+					type: 'button' as const,
+					text: {
+						type: 'plain_text' as const,
+						text: isLocationUrl ? 'リンクを開く' : 'マップで場所を開く',
+						emoji: false,
+					},
+					url: placeUrl,
+					style: 'primary' as const,
+				},
+			] : []),
+			...(event.htmlLink ? [
+				{
+					type: 'button' as const,
+					text: {
+						type: 'plain_text' as const,
+						text: 'カレンダーで開く',
+						emoji: false,
+					},
+					url: event.htmlLink,
+				},
+			] : []),
+		],
+	});
+
+	return blocks;
+};
+
+export interface EventMessage {
+	text: string;
+	blocks: KnownBlock[];
+}
+
+export const eventAddedMessage = (event: CalendarEvent): EventMessage => ({
+	text: `📅 予定が追加されました: ${event.summary ?? '(タイトルなし)'}`,
+	blocks: [
+		{
+			type: 'section',
+			text: {type: 'plain_text', text: '📅 予定が追加されました', emoji: true},
+		},
+		...buildEventDetailBlocks(event),
+	],
+});
+
+export const eventDeletedMessage = (event: CalendarEvent): EventMessage => ({
+	text: `🗑️ 予定が削除されました: ${event.summary ?? '(タイトルなし)'}`,
+	blocks: [
+		{
+			type: 'section',
+			text: {type: 'plain_text', text: '🗑️ 予定が削除されました', emoji: true},
+		},
+		...buildEventDetailBlocks(event),
+	],
+});
+
+export const eventStartMessage = (event: CalendarEvent): EventMessage => ({
+	text: `🔔予定が始まるよ～: ${event.summary ?? '(タイトルなし)'}`,
+	blocks: [
+		{
+			type: 'section',
+			text: {type: 'plain_text', text: '🔔予定が始まるよ～', emoji: true},
+		},
+		...buildEventDetailBlocks(event),
+	],
+});
+
+export const eventBeforeMessage = (event: CalendarEvent, minutes: number): EventMessage => ({
+	text: `⏰ ${minutes}分後に予定が始まるよ～: ${event.summary ?? '(タイトルなし)'}`,
+	blocks: [
+		{
+			type: 'section',
+			text: {
+				type: 'plain_text',
+				text: `⏰ ${minutes}分後に予定が始まるよ～`,
+				emoji: true,
+			},
+		},
+		...buildEventDetailBlocks(event),
+	],
+});
+
+interface SplitEvents {
+	shortEvents: CalendarEvent[];
+	longEvents: {
+		event: CalendarEvent;
+		durationInDays: number;
+		index: number;
+	}[];
+}
+
+const splitEvents = (events: CalendarEvent[], now: Date): SplitEvents => {
+	const shortEvents: CalendarEvent[] = [];
+	const longEvents: {event: CalendarEvent; durationInDays: number; index: number}[] = [];
+
+	for (const event of events) {
+		// All-day and one-day event
+		if (
+			!event.start?.dateTime && !event.end?.dateTime &&
+			event.start?.date && event.end?.date &&
+			incrementDate(event.start.date, 1) === event.end.date
+		) {
+			shortEvents.push(event);
+			continue;
+		}
+
+		// Event that starts after the current time
+		if (event.start?.dateTime) {
+			const startTime = dayjs(event.start.dateTime);
+			if (startTime.isAfter(now)) {
+				shortEvents.push(event);
+				continue;
+			}
+		}
+
+		const start = dayjs(event.start?.dateTime ?? event.start?.date);
+		const end = dayjs(event.end?.dateTime ?? event.end?.date);
+		const durationInDays = end.diff(start, 'day');
+		longEvents.push({
+			event,
+			durationInDays,
+			index: -start.diff(now, 'day'),
+		});
+	}
+
+	shortEvents.sort((a, b) => {
+		const aTime = a.start?.dateTime ?? a.start?.date ?? '';
+		const bTime = b.start?.dateTime ?? b.start?.date ?? '';
+		return aTime.localeCompare(bTime);
+	});
+
+	longEvents.sort(({event: a}, {event: b}) => {
+		const aTime = a.start?.dateTime ?? a.start?.date ?? '';
+		const bTime = b.start?.dateTime ?? b.start?.date ?? '';
+		return aTime.localeCompare(bTime);
+	});
+
+	return {shortEvents, longEvents};
+};
+
+const buildEventListBlocks = (events: SplitEvents, mode: 'daily' | 'weekly'): KnownBlock[] => {
+	const sections: SectionBlock[] = [];
+
+	if (events.shortEvents.length > 0) {
+		const items: string[] = [
+			mode === 'daily' ? '＊本日の予定はこちら！＊' : '＊今週の予定はこちら！＊',
+		];
+
+		for (const event of events.shortEvents) {
+			const eventTitle = event.htmlLink ? `<${event.htmlLink}|${event.summary ?? '(タイトルなし)'}>` : `${event.summary ?? '(タイトルなし)'}`;
+			if (event.start?.dateTime) {
+				items.push(`● ${formatEventTime(event, mode === 'weekly')} ＊${eventTitle}＊`);
+			} else {
+				const startTs = Math.floor(new Date(event.start?.date ?? '').getTime() / 1000);
+				const dateString = mode === 'daily' ? '' : `<!date^${startTs}^{date_short_pretty}|${event.start?.date}>`;
+				items.push(`● ${dateString}終日 ＊${eventTitle}＊`);
+			}
+		}
+
+		sections.push({
+			type: 'section',
+			text: {
+				type: 'mrkdwn',
+				text: items.join('\n'),
+			},
+		});
+	}
+
+	if (events.longEvents.length > 0) {
+		const items: string[] = [
+			'＊現在開催中のイベントはこちら！＊',
+		];
+
+		for (const {event, index, durationInDays} of events.longEvents) {
+			const eventTitle = event.htmlLink ? `<${event.htmlLink}|${event.summary ?? '(タイトルなし)'}>` : `${event.summary ?? '(タイトルなし)'}`;
+			let note = '';
+			if (mode === 'daily') {
+				if (index === 0) {
+					note = ' (1日目🏌️)';
+				}
+				if (index + 1 === durationInDays) {
+					note = ' (最終日⛳)';
+				}
+			}
+			items.push(`● ${formatEventTime(event, mode === 'weekly')} ＊${eventTitle}＊${note}`);
+		}
+
+		sections.push({
+			type: 'section',
+			text: {
+				type: 'mrkdwn',
+				text: items.join('\n'),
+			},
+		});
+	}
+
+	return sections;
+};
+
+export const dailySummaryMessage = (events: CalendarEvent[], now: Date): EventMessage => ({
+	text: `📅 今日の予定一覧 (${events.length}件)`,
+	blocks: [
+		{
+			type: 'header',
+			text: {
+				type: 'plain_text',
+				text: '☀️TSGのみなさーん、おはようございます！',
+				emoji: true,
+			},
+		},
+		...buildEventListBlocks(splitEvents(events, now), 'daily'),
+	],
+});
+
+export const weeklySummaryMessage = (events: CalendarEvent[], now: Date): EventMessage => ({
+	text: `📆 今週の予定一覧 (${events.length}件)`,
+	blocks: [
+		{
+			type: 'header',
+			text: {
+				type: 'plain_text',
+				text: '今週の予定一覧だよ～',
+				emoji: true,
+			},
+		},
+		...buildEventListBlocks(splitEvents(events, now), 'weekly'),
+	],
+});

--- a/google-calendar/views/eventMessages.ts
+++ b/google-calendar/views/eventMessages.ts
@@ -2,6 +2,9 @@ import type {KnownBlock, SectionBlock} from '@slack/bolt';
 import dayjs from '../../lib/dayjs';
 import type {CalendarEvent} from '../types';
 
+const MAX_DESCRIPTION_LENGTH = 200;
+const MAX_SUBTITLE_LENGTH = 150;
+
 const incrementDate = (dateString: string, count: number) => {
 	const date = new Date(dateString);
 	date.setDate(date.getDate() + count);
@@ -42,15 +45,15 @@ const buildEventDetailBlocks = (event: CalendarEvent): KnownBlock[] => {
 	}
 
 	const normalizedDescription = event.description?.replaceAll('<br>', '\n') ?? '';
-	const hasMore = normalizedDescription.length > 199;
-	const description = hasMore ? `${normalizedDescription.slice(0, 199)}⋯` : normalizedDescription;
+	const hasMore = normalizedDescription.length > MAX_DESCRIPTION_LENGTH - 1;
+	const description = hasMore ? `${normalizedDescription.slice(0, MAX_DESCRIPTION_LENGTH - 1)}⋯` : normalizedDescription;
 
 	let subtitle = formatEventTime(event, true);
 	if (event.location) {
 		subtitle += ` / ${event.location}`;
 	}
-	if (subtitle.length > 149) {
-		subtitle = `${subtitle.slice(0, 149)}⋯`;
+	if (subtitle.length > MAX_SUBTITLE_LENGTH - 1) {
+		subtitle = `${subtitle.slice(0, MAX_SUBTITLE_LENGTH - 1)}⋯`;
 	}
 
 	blocks.push({

--- a/google-calendar/views/settingsModal.ts
+++ b/google-calendar/views/settingsModal.ts
@@ -1,0 +1,97 @@
+import type {View, KnownBlock} from '@slack/web-api';
+import type {Subscription} from '../types';
+
+const DAY_NAMES = ['日', '月', '火', '水', '木', '金', '土'];
+
+const calendarUrl = (calendarId: string): string => `https://calendar.google.com/calendar/embed?src=${encodeURIComponent(calendarId)}`;
+
+const formatNotificationSummary = (sub: Subscription): string => {
+	const items: string[] = [];
+	if (sub.onAddDelete) {
+		items.push('追加/削除通知');
+	}
+	if (sub.onStart) {
+		items.push('開始通知');
+	}
+	if (sub.minutesBefore !== null) {
+		items.push(`${sub.minutesBefore}分前通知`);
+	}
+	if (sub.dailyHour !== null) {
+		items.push(`毎日${sub.dailyHour}時サマリー`);
+	}
+	if (sub.weeklyDay !== null && sub.weeklyHour !== null) {
+		items.push(`毎週${DAY_NAMES[sub.weeklyDay]}曜日${sub.weeklyHour}時サマリー`);
+	}
+	return items.length > 0 ? items.join(' / ') : '(通知なし)';
+};
+
+export default (subscriptions: Subscription[], channelId: string): View => {
+	const blocks: KnownBlock[] = [
+		{
+			type: 'section',
+			text: {
+				type: 'mrkdwn',
+				text: 'このチャンネルの Google Calendar 通知設定です。',
+			},
+		},
+	];
+
+	if (subscriptions.length === 0) {
+		blocks.push({
+			type: 'section',
+			text: {
+				type: 'mrkdwn',
+				text: '_通知がまだ設定されていません。_',
+			},
+		});
+	} else {
+		for (const sub of subscriptions) {
+			blocks.push({type: 'divider'});
+			blocks.push({
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `*<${calendarUrl(sub.calendarId)}|${sub.calendarName}>*\n\`${sub.calendarId}\`\n*通知設定:* ${formatNotificationSummary(sub)}`,
+				},
+				accessory: {
+					type: 'button',
+					text: {type: 'plain_text', text: '削除'},
+					style: 'danger',
+					action_id: 'gcal_delete_subscription',
+					value: sub.id,
+					confirm: {
+						title: {type: 'plain_text', text: '削除の確認'},
+						text: {
+							type: 'mrkdwn',
+							text: `カレンダー *${sub.calendarName}* の通知を削除しますか？`,
+						},
+						confirm: {type: 'plain_text', text: '削除'},
+						deny: {type: 'plain_text', text: 'キャンセル'},
+					},
+				},
+			});
+		}
+	}
+
+	blocks.push({type: 'divider'});
+	blocks.push({
+		type: 'actions',
+		elements: [
+			{
+				type: 'button',
+				text: {type: 'plain_text', text: '+ 通知を追加', emoji: true},
+				style: 'primary',
+				action_id: 'gcal_show_add_subscription',
+			},
+		],
+	});
+
+	return {
+		type: 'modal',
+		callback_id: 'gcal_settings',
+		title: {type: 'plain_text', text: 'Calendarの設定'},
+		close: {type: 'plain_text', text: '閉じる'},
+		private_metadata: JSON.stringify({channelId}),
+		blocks,
+	};
+};

--- a/index.ts
+++ b/index.ts
@@ -143,6 +143,7 @@ const productionBots = [
 	'nmpz',
 	'autogen-quiz',
 	'twenty-questions',
+	'google-calendar',
 ];
 
 const developmentBots = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4498,9 +4498,10 @@
       }
     },
     "node_modules/@slack/types": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.14.0.tgz",
-      "integrity": "sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.21.1.tgz",
+      "integrity": "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12.13.0",
         "npm": ">= 6.12.0"
@@ -40487,9 +40488,9 @@
       }
     },
     "@slack/types": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.14.0.tgz",
-      "integrity": "sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA=="
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.21.1.tgz",
+      "integrity": "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ=="
     },
     "@slack/web-api": {
       "version": "7.5.0",


### PR DESCRIPTION
## 概要

- Google Calendarのイベントをチャンネルに通知する `google-calendar` プラグインを追加
- 通知タイプは5種類: イベント追加/削除、イベント開始、N分前通知、毎日サマリー、毎週サマリー
- `/calendar` スラッシュコマンドからSlackモーダルでチャンネルごとに設定可能
- カレンダーへのアクセスエラー時は `GOOGLE_APPLICATION_CREDENTIALS` のJSONから読み取ったサービスアカウントのメールアドレスを案内

## 機能詳細

- Google Calendar同期トークンを使ったインクリメンタル同期（410 Gone発生時はトークンをリセットして再同期）
- 通知の重複送信を防ぐデduplication機能
- カレンダーの表示名を保存し、設定モーダルではリンク付きで表示
- Block Kitの `card` ブロックでイベントをリッチ表示（場所のGoogleマップリンク・カレンダーリンク付き）
- 毎日・毎週サマリーの重複送信を日付文字列で管理

## スクリーンショット

<img width="293" height="202" alt="image" src="https://github.com/user-attachments/assets/716fbf7c-c0e7-4065-8af6-1b9817afc3cc" />

<img width="329" height="308" alt="image" src="https://github.com/user-attachments/assets/ec89265d-cc0a-41ac-bf34-8d76c627575a" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)