### PR TITLE
Fix invalid_blocks error when calendar event has no description

### DIFF
--- a/google-calendar/views/eventMessages.ts
+++ b/google-calendar/views/eventMessages.ts
@@ -68,11 +68,13 @@ const buildEventDetailBlocks = (event: CalendarEvent): KnownBlock[] => {
 			text: subtitle,
 			verbatim: false,
 		},
-		body: {
-			type: 'mrkdwn',
-			text: description,
-			verbatim: false,
-		},
+		...(description && {
+			body: {
+				type: 'mrkdwn',
+				text: description,
+				verbatim: false,
+			},
+		}),
 		actions: [
 			...(placeUrl ? [
 				{


### PR DESCRIPTION
## Summary

- `google-calendar` ボットのイベント通知で、説明(description)が空のイベントを通知しようとすると Slack API が `invalid_blocks` エラーを返す問題を修正
- `buildEventDetailBlocks` 内の `card` ブロックの `body.text` に空文字列が渡されており、Slack の「must be more than 0 characters」バリデーションに引っかかっていた
- `description` が空の場合は `body` フィールドごと省略するよう変更

## Root cause

```
"errors": [
  "failed to match all allowed schemas [json-pointer:/blocks/1/body]",
  "must be more than 0 characters [json-pointer:/blocks/1/body/text]"
]
```

`event.description` が未設定のとき `rawDescription = ''` となり、そのまま `body.text: ''` として Slack に送信されていた。

## Test plan

- [ ] 説明なしのカレンダーイベントで開始通知・事前通知が正常に送信されること
- [ ] 説明ありのカレンダーイベントでは引き続き `body` が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)