### PR TITLE
Improve Google Calendar event messages with event titles and localized timestamps

### DIFF
--- a/google-calendar/calendarClient.ts
+++ b/google-calendar/calendarClient.ts
@@ -3,6 +3,8 @@ import {google, calendar_v3} from 'googleapis';
 import dayjs from '../lib/dayjs';
 import type {CalendarEvent} from './types';
 
+const TIMEZONE = 'Asia/Tokyo';
+
 const sanitizeHtml = (html: string): string => (
 	html
 		.replace(/<br\s*\/?>/gi, '\n')
@@ -136,8 +138,8 @@ export const listUpcomingEvents = async (
 	const filteredEvents = allEvents.filter((event) => {
 		// Events with dateTime
 		if (event.start?.dateTime && event.end?.dateTime) {
-			const startDateTime = dayjs(event.start.dateTime).tz('Asia/Tokyo');
-			const endDateTime = dayjs(event.end.dateTime).tz('Asia/Tokyo');
+			const startDateTime = dayjs(event.start.dateTime).tz(TIMEZONE);
+			const endDateTime = dayjs(event.end.dateTime).tz(TIMEZONE);
 			if (
 				startDateTime.hour() === 0 &&
 				startDateTime.minute() === 0 &&
@@ -151,7 +153,7 @@ export const listUpcomingEvents = async (
 
 		// All-day events
 		if (event.start?.date && event.end?.date && !event.start.dateTime && !event.end.dateTime) {
-			const startDate = dayjs(event.start.date).tz('Asia/Tokyo');
+			const startDate = dayjs(event.start.date).tz(TIMEZONE);
 			if (
 				startDate.isAfter(timeMax.getTime() - 24 * 60 * 60 * 1000)
 			) {

--- a/google-calendar/discordSync.ts
+++ b/google-calendar/discordSync.ts
@@ -159,7 +159,7 @@ const truncate = (text: string, maxLength: number): string => (
 
 // Prevent writing the Discord event URL back as the Discord event's own location field.
 const resolveDiscordLocation = (location: string | null | undefined): string => {
-	if (!location || /^https:\/\/discord\.com\/events\//.test(location)) {
+	if (!location || (/^https:\/\/discord\.com\/events\//).test(location)) {
 		return 'Google Calendar';
 	}
 	return location;

--- a/google-calendar/views/eventMessages.ts
+++ b/google-calendar/views/eventMessages.ts
@@ -4,6 +4,7 @@ import type {CalendarEvent} from '../types';
 
 const MAX_DESCRIPTION_LENGTH = 200;
 const MAX_SUBTITLE_LENGTH = 150;
+const TIMEZONE = 'Asia/Tokyo';
 
 const incrementDate = (dateString: string, count: number) => {
 	const date = new Date(dateString);
@@ -14,23 +15,23 @@ const incrementDate = (dateString: string, count: number) => {
 const formatEventTime = (event: CalendarEvent, includeDate: boolean): string => {
 	if (event.start?.dateTime) {
 		const startTs = Math.floor(new Date(event.start.dateTime).getTime() / 1000);
-		const localStartTime = dayjs(event.start.dateTime).tz('Asia/Tokyo').format('HH:mm');
+		const localStartTime = dayjs(event.start.dateTime).tz(TIMEZONE).format('HH:mm');
 		const startString = `<!date^${startTs}^${includeDate ? '{date_short_pretty} {time}' : '{time}'}|${localStartTime}>`;
 		if (event.end?.dateTime) {
 			const endTs = Math.floor(new Date(event.end.dateTime).getTime() / 1000);
-			const localEndTime = dayjs(event.end.dateTime).tz('Asia/Tokyo').format('HH:mm');
+			const localEndTime = dayjs(event.end.dateTime).tz(TIMEZONE).format('HH:mm');
 			const endString = `<!date^${endTs}^{time}|${localEndTime}>`;
 			return `${startString} 〜 ${endString}`;
 		}
 		return startString;
 	}
 	if (event.start?.date && event.end?.date) {
-		const startDate = dayjs(event.start.date).tz('Asia/Tokyo').format('M月D日');
-		const endDate = dayjs(event.end.date).tz('Asia/Tokyo').add(-1, 'day').format('M月D日');
+		const startDate = dayjs(event.start.date).tz(TIMEZONE).format('M月D日');
+		const endDate = dayjs(event.end.date).tz(TIMEZONE).add(-1, 'day').format('M月D日');
 		return `${startDate} 〜 ${endDate}`;
 	}
 	if (event.start?.date) {
-		const startDate = dayjs(event.start.date).tz('Asia/Tokyo').format('M月D日');
+		const startDate = dayjs(event.start.date).tz(TIMEZONE).format('M月D日');
 		return `${startDate} (終日)`;
 	}
 	return '(日時未設定)';
@@ -142,9 +143,8 @@ export const eventStartMessage = (event: CalendarEvent): EventMessage => ({
 		{
 			type: 'section',
 			text: {
-				type: 'plain_text',
+				type: 'mrkdwn',
 				text: `🔔 ${event.summary ? `＊${event.summary}＊` : '予定'}が始まるよ～`,
-				emoji: true,
 			},
 		},
 		...buildEventDetailBlocks(event),
@@ -157,9 +157,8 @@ export const eventBeforeMessage = (event: CalendarEvent, minutes: number): Event
 		{
 			type: 'section',
 			text: {
-				type: 'plain_text',
+				type: 'mrkdwn',
 				text: `⏰ ${minutes}分後に${event.summary ? `＊${event.summary}＊` : '予定'}が始まるよ～`,
-				emoji: true,
 			},
 		},
 		...buildEventDetailBlocks(event),

--- a/google-calendar/views/eventMessages.ts
+++ b/google-calendar/views/eventMessages.ts
@@ -14,11 +14,15 @@ const incrementDate = (dateString: string, count: number) => {
 const formatEventTime = (event: CalendarEvent, includeDate: boolean): string => {
 	if (event.start?.dateTime) {
 		const startTs = Math.floor(new Date(event.start.dateTime).getTime() / 1000);
+		const localStartTime = dayjs(event.start.dateTime).tz('Asia/Tokyo').format('HH:mm');
+		const startString = `<!date^${startTs}^${includeDate ? '{date_short_pretty} {time}' : '{time}'}|${localStartTime}>`;
 		if (event.end?.dateTime) {
 			const endTs = Math.floor(new Date(event.end.dateTime).getTime() / 1000);
-			return `<!date^${startTs}^${includeDate ? '{date_short_pretty} {time}' : '{time}'}|${event.start.dateTime}> 〜 <!date^${endTs}^{time}|${event.end.dateTime}>`;
+			const localEndTime = dayjs(event.end.dateTime).tz('Asia/Tokyo').format('HH:mm');
+			const endString = `<!date^${endTs}^{time}|${localEndTime}>`;
+			return `${startString} 〜 ${endString}`;
 		}
-		return `<!date^${startTs}^${includeDate ? '{date_short_pretty} {time}' : '{time}'}|${event.start.dateTime}>`;
+		return startString;
 	}
 	if (event.start?.date && event.end?.date) {
 		const startDate = dayjs(event.start.date).tz('Asia/Tokyo').format('M月D日');
@@ -133,24 +137,28 @@ export const eventDeletedMessage = (event: CalendarEvent): EventMessage => ({
 });
 
 export const eventStartMessage = (event: CalendarEvent): EventMessage => ({
-	text: `🔔予定が始まるよ～: ${event.summary ?? '(タイトルなし)'}`,
+	text: `🔔 ${event.summary ?? '予定'}が始まるよ～`,
 	blocks: [
 		{
 			type: 'section',
-			text: {type: 'plain_text', text: '🔔予定が始まるよ～', emoji: true},
+			text: {
+				type: 'plain_text',
+				text: `🔔 ${event.summary ? `＊${event.summary}＊` : '予定'}が始まるよ～`,
+				emoji: true,
+			},
 		},
 		...buildEventDetailBlocks(event),
 	],
 });
 
 export const eventBeforeMessage = (event: CalendarEvent, minutes: number): EventMessage => ({
-	text: `⏰ ${minutes}分後に予定が始まるよ～: ${event.summary ?? '(タイトルなし)'}`,
+	text: `⏰ ${minutes}分後に${event.summary ?? '予定'}が始まるよ～`,
 	blocks: [
 		{
 			type: 'section',
 			text: {
 				type: 'plain_text',
-				text: `⏰ ${minutes}分後に予定が始まるよ～`,
+				text: `⏰ ${minutes}分後に${event.summary ? `＊${event.summary}＊` : '予定'}が始まるよ～`,
 				emoji: true,
 			},
 		},


### PR DESCRIPTION
## Summary

- イベント通知メッセージ (`eventStartMessage`, `eventBeforeMessage`) にイベントタイトルを含めるよう改善
- Slack の `<!date^...>` フォーマットのフォールバック文字列を `event.start.dateTime` (ISO文字列) から日本時間の時刻フォーマット (例: `14:30`) に変更し、可読性を向上
- lint エラー修正: `discordSync.ts` の正規表現を括弧でラップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)