### PR TITLE
atcoder: Use AtCoder Problems API for typical90/ABS solve tracking

### DIFF
--- a/atcoder/index.ts
+++ b/atcoder/index.ts
@@ -15,7 +15,7 @@ import {getMemberIcon, getMemberName} from '../lib/slackUtils';
 import State from '../lib/state';
 // eslint-disable-next-line no-unused-vars
 import type {Results, Standings} from './types';
-import {crawlSubmissionsByUser} from './utils';
+import {fetchUserACsInContest} from './utils';
 
 const log = logger.child({bot: 'atcoder'});
 const mutex = new Mutex();
@@ -484,36 +484,24 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
 		const oneDayLater = now.clone().add(1, 'day');
 
 		// typical shojin notifications
-		log.info('[atcoder-daily] Fetching result of typical90');
-		const {userStandings} = await getStandings('typical90');
-		const typicalSolves = new Map<string, number>();
-
-		for (const {user, standing} of userStandings) {
-			if (standing === undefined) {
-				continue;
-			}
-			const solves = Object.values(standing.TaskResults).filter((result) => result.Status === 1).length;
-			typicalSolves.set(user, solves);
-		}
-
 		const dataValues = [];
 		let increase = 0;
 
 		for (const user of state.users) {
-			log.info(`[atcoder-daily] Fetching result of ABS (user = ${user.atcoder})`);
+			log.info(`[atcoder-daily] Fetching solves for user ${user.atcoder}`);
 
-			await new Promise((resolve) => setTimeout(resolve, 3000));
-			const submissions = await crawlSubmissionsByUser('abs', user.atcoder);
-			const acceptedProblems = new Set<string>();
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 1000);
+			});
+			const absACs = await fetchUserACsInContest(user.atcoder, 'abs');
+			absACs.delete('practice_1');
+			const absSolve = absACs.size;
 
-			for (const {result, problemId} of submissions) {
-				if (result === 'AC' && problemId !== 'practice_1') {
-					acceptedProblems.add(problemId);
-				}
-			}
-
-			const absSolve = acceptedProblems.size;
-			const typicalSolve = typicalSolves.get(user.slack) || 0;
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 1000);
+			});
+			const typicalACs = await fetchUserACsInContest(user.atcoder, 'typical90');
+			const typicalSolve = typicalACs.size;
 
 			const previousAbsSolve = (await get(user.slack, 'atcoder-abs-solves')) || 0;
 			if (typeof previousAbsSolve !== 'number') {

--- a/atcoder/utils.ts
+++ b/atcoder/utils.ts
@@ -1,101 +1,44 @@
-import {last} from 'lodash';
-import scrapeIt from 'scrape-it';
+import axios from 'axios';
 
-interface Submission {
-	time: Date,
-	problemId: string,
-	problemName: string,
-	userId: string,
-	languageId: number,
+interface AtCoderProblemsSubmission {
+	id: number,
+	epoch_second: number,
+	problem_id: string,
+	contest_id: string,
+	user_id: string,
 	language: string,
-	point: number
+	point: number,
 	length: number,
 	result: string,
-	executionTime: number,
-	memoryUsage: number,
-	id: number,
+	execution_time: number,
 }
 
-interface SubmissionsData {
-	maxPage: number,
-	submissions: Submission[],
-}
+export const fetchUserACsInContest = async (userId: string, contestId: string): Promise<Set<string>> => {
+	const acProblems = new Set<string>();
+	let fromSecond = 0;
 
-export const crawlSubmissionsByUser = async (contestId: string, user: string) => {
-	let page = 1;
-	const submissionsMap: Map<number, Submission> = new Map();
+	while (true) {
+		const {data} = await axios.get<AtCoderProblemsSubmission[]>(
+			'https://kenkoooo.com/atcoder/atcoder-api/v3/user/submissions',
+			{params: {user: userId, from_second: fromSecond}},
+		);
 
-	while (page < 100) {
-		const url = `https://atcoder.jp/contests/${contestId}/submissions?f.User=${user}&page=${page}`;
-		const {data} = await scrapeIt<SubmissionsData>(url, {
-			maxPage: {
-				selector: 'div:last-child > .pagination > li:last-child',
-				convert: (text) => parseInt(text),
-			},
-			submissions: {
-				listItem: '.panel-submission .table tbody > tr',
-				data: {
-					time: {
-						selector: 'td:nth-child(1)',
-						convert: (d) => new Date(d),
-					},
-					problemId: {
-						selector: 'td:nth-child(2) > a',
-						attr: 'href',
-						convert: (text) => last(text.split('/')),
-					},
-					problemName: {
-						selector: 'td:nth-child(2)',
-					},
-					userId: {
-						selector: 'td:nth-child(3)',
-					},
-					languageId: {
-						selector: 'td:nth-child(4) > a',
-						attr: 'href',
-						convert: (u) => parseInt(new URL(u, url).searchParams.get('f.Language')),
-					},
-					language: {
-						selector: 'td:nth-child(4)',
-					},
-					point: {
-						selector: 'td:nth-child(5)',
-						convert: (text) => parseInt(text),
-					},
-					length: {
-						selector: 'td:nth-child(6)',
-						convert: (text) => parseInt(text),
-					},
-					result: {
-						selector: 'td:nth-child(7)',
-					},
-					executionTime: {
-						selector: 'td:nth-child(8)',
-						convert: (text) => parseInt(text),
-					},
-					memoryUsage: {
-						selector: 'td:nth-child(9)',
-						convert: (text) => parseInt(text),
-					},
-					id: {
-						selector: 'td:last-child > a',
-						attr: 'href',
-						convert: (text) => parseInt(last(text.split('/'))),
-					},
-				},
-			},
-		});
-
-		for (const submission of data.submissions) {
-			submissionsMap.set(submission.id, submission);
+		for (const sub of data) {
+			if (sub.contest_id === contestId && sub.result === 'AC') {
+				acProblems.add(sub.problem_id);
+			}
 		}
 
-		if (data.submissions.length === 0 || data.maxPage === page) {
+		if (data.length < 500) {
 			break;
 		}
 
-		page++;
+		const lastSecond = Math.max(...data.map((s) => s.epoch_second));
+		fromSecond = lastSecond + 1;
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 1000);
+		});
 	}
 
-	return Array.from(submissionsMap.values()).sort((a, b) => a.time.getTime() - b.time.getTime());
+	return acProblems;
 };

--- a/atcoder/utils.ts
+++ b/atcoder/utils.ts
@@ -1,4 +1,6 @@
+import path from 'path';
 import axios from 'axios';
+import nodePersist from 'node-persist';
 
 interface AtCoderProblemsSubmission {
 	id: number,
@@ -13,9 +15,34 @@ interface AtCoderProblemsSubmission {
 	execution_time: number,
 }
 
+interface UserSubmissionCache {
+	lastFetchedSecond: number,
+	acsByContest: {[contestId: string]: string[]},
+}
+
+let storagePromise: Promise<nodePersist.LocalStorage> | null = null;
+
+const getStorage = (): Promise<nodePersist.LocalStorage> => {
+	if (!storagePromise) {
+		const storage = nodePersist.create({
+			dir: path.resolve(__dirname, '__state__'),
+		});
+		storagePromise = storage.init().then(() => storage);
+	}
+	return storagePromise;
+};
+
 export const fetchUserACsInContest = async (userId: string, contestId: string): Promise<Set<string>> => {
-	const acProblems = new Set<string>();
-	let fromSecond = 0;
+	const storage = await getStorage();
+
+	const cacheKey = `submissions-${userId}`;
+	const cached: UserSubmissionCache = (await storage.getItem(cacheKey)) ?? {
+		lastFetchedSecond: 0,
+		acsByContest: {},
+	};
+
+	let fromSecond = cached.lastFetchedSecond > 0 ? cached.lastFetchedSecond + 1 : 0;
+	let maxEpochSecond = cached.lastFetchedSecond;
 
 	while (true) {
 		const {data} = await axios.get<AtCoderProblemsSubmission[]>(
@@ -24,8 +51,16 @@ export const fetchUserACsInContest = async (userId: string, contestId: string): 
 		);
 
 		for (const sub of data) {
-			if (sub.contest_id === contestId && sub.result === 'AC') {
-				acProblems.add(sub.problem_id);
+			if (sub.epoch_second > maxEpochSecond) {
+				maxEpochSecond = sub.epoch_second;
+			}
+			if (sub.result === 'AC') {
+				if (!cached.acsByContest[sub.contest_id]) {
+					cached.acsByContest[sub.contest_id] = [];
+				}
+				if (!cached.acsByContest[sub.contest_id].includes(sub.problem_id)) {
+					cached.acsByContest[sub.contest_id].push(sub.problem_id);
+				}
 			}
 		}
 
@@ -33,12 +68,14 @@ export const fetchUserACsInContest = async (userId: string, contestId: string): 
 			break;
 		}
 
-		const lastSecond = Math.max(...data.map((s) => s.epoch_second));
-		fromSecond = lastSecond + 1;
+		fromSecond = Math.max(...data.map((s) => s.epoch_second)) + 1;
 		await new Promise<void>((resolve) => {
 			setTimeout(resolve, 1000);
 		});
 	}
 
-	return acProblems;
+	cached.lastFetchedSecond = maxEpochSecond;
+	await storage.setItem(cacheKey, cached);
+
+	return new Set(cached.acsByContest[contestId] ?? []);
 };


### PR DESCRIPTION
## Summary

- `getStandings('typical90')` がAtCoderの認証が必要な順位表APIを呼び出していたが、順位表が非公開化されて動作しなくなっていた
- `crawlSubmissionsByUser` によるAtCoderウェブサイトのスクレイピングも同様に動作しなくなっていた
- これらを [AtCoder Problems API](https://github.com/kenkoooo/AtCoderProblems/blob/master/doc/api.md) に置き換え、`/atcoder-api/v3/user/submissions` エンドポイントを使ってユーザーごとのAC済み問題を取得するように変更

Fixes #1196

## Test plan

- [ ] `postDaily` が毎朝9時に正常に実行され、typical90・ABS の精進状況チャートが投稿されること
- [ ] `atcoder-abs-solves` / `atcoder-typical-solves` カウンターが正しく更新され、実績（積み重ね/増築王高橋君/ほんとうのたたかい）が解除できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)