### PR TITLE
atcoder: デイリー通知から Weekday Contest と Daily Training を除外

### DIFF
--- a/atcoder/index.ts
+++ b/atcoder/index.ts
@@ -584,7 +584,8 @@ export default async ({eventClient, webClient: slack}: SlackInterface) => {
 		}
 
 		// contest notifications
-		const contests = state.contests.filter((contest) => now.valueOf() < contest.date && contest.date <= oneDayLater.valueOf());
+		const contests = state.contests.filter((contest) => now.valueOf() < contest.date && contest.date <= oneDayLater.valueOf())
+			.filter((contest) => !SILENT_CONTEST_PREFIXES.some((prefix) => contest.id.startsWith(prefix)));
 
 		log.info(`[atcoder-daily] Posting daily notifications of ${contests.length} contests...`);
 


### PR DESCRIPTION
## Summary

- 朝9時の `postDaily` 内のコンテスト一覧通知でも `SILENT_CONTEST_PREFIXES` (`awc*`, `adt_*`) によるフィルタリングを適用
- これにより Weekday Contest・Daily Training が毎朝デイリー通知に現れなくなる
- 既存の「新規追加通知」「15分前・開始通知」の抑制ロジック（#1181 で追加済み）と同じ定数を再利用

## Test plan

- [ ] Weekday Contest (`awc*`) または Daily Training (`adt_*`) のコンテストが当日開催予定のとき、朝9時の通知に含まれないことを確認
- [ ] 通常コンテスト（`abc*`, `arc*`, `agc*` 等）は引き続き通知されることを確認

Fixes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)