### PR TITLE
ci: デプロイ前に functions/.env を Secrets から生成する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      - name: Create functions/.env
+        run: |
+          echo "SLACK_TOKEN=${{ secrets.FUNCTIONS_SLACK_TOKEN }}" >> functions/.env
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.FUNCTIONS_AWS_ACCESS_KEY_ID }}" >> functions/.env
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.FUNCTIONS_AWS_SECRET_ACCESS_KEY }}" >> functions/.env
+
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:


### PR DESCRIPTION
## 概要

#1085 の対応で `functions/.env` が gitignore されるようになったため、GitHub Actions のデプロイ時に環境変数が読み込まれない問題を修正する。

デプロイステップの直前に、GitHub Actions Secrets から `functions/.env` を生成するステップを追加する。

## 必要な設定

このワークフローが正常に動作するには、以下の3つの Secrets をリポジトリに登録する必要がある：

| Secret 名 | 値 |
|---|---|
| `FUNCTIONS_SLACK_TOKEN` | Slack Bot Token (`xoxb-...`) |
| `FUNCTIONS_AWS_ACCESS_KEY_ID` | AWS Access Key ID |
| `FUNCTIONS_AWS_SECRET_ACCESS_KEY` | AWS Secret Access Key |

Settings → Secrets and variables → Actions から登録してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)