### PR TITLE
context-free: tahoiya/bot.js削除に伴うimport先の修正

### DIFF
--- a/context-free/index.ts
+++ b/context-free/index.ts
@@ -7,8 +7,7 @@ import getReading from '../lib/getReading';
 /* eslint-disable no-unused-vars */
 import type {SlackInterface, SlashCommandEndpoint} from '../lib/slack';
 import {getMemberName, getMemberIcon} from '../lib/slackUtils';
-// @ts-expect-error
-import tahoiyaBot from '../tahoiya/bot';
+import {getAIBotMeaning} from '../tahoiya/aibot';
 import {tags} from './cfp-tags';
 
 const normalizeMeaning = (input: string) => {
@@ -86,10 +85,10 @@ const randomWord = async (): Promise<Word> => {
   });
   if (date === '4/1') {
     const reading = await getReading(response.data.word);
-    const result = await tahoiyaBot.getResult(reading, 'tahoiyabot-02');
+    const aiResult = await getAIBotMeaning(reading, 'tahoiyabot-02');
     return {
       word: response.data.word,
-      description: result.result,
+      description: aiResult?.result ?? response.data.word,
     };
   }
   const description = extractMeaning(response.data.description);


### PR DESCRIPTION
## Summary

- PR #1195（tahoiyaリライト）で `tahoiya/bot.js` が削除されたが、`context-free/index.ts` が `../tahoiya/bot` をimportしたままになっていた
- これにより起動時に `MODULE_NOT_FOUND` エラーが発生し、context-freeボットがロードされなくなっていた
- `tahoiya/bot.js` の `getResult` を、新しい `tahoiya/aibot.ts` の `getAIBotMeaning` に置き換えて修正

## Test plan

- [ ] 本番サーバーで context-free ボットが正常にロードされることを確認
- [ ] 4月1日以外の日（通常時）に `/cfp` コマンドが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)