### PR TITLE
fix: fastify v5破壊的変更によるFST_ERR_PLUGIN_INVALID_ASYNC_HANDLERを修正

### DIFF
--- a/amongyou/index.ts
+++ b/amongyou/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import type {EventEmitter} from 'events';
 import {ChatPostMessageArguments, WebClient} from '@slack/web-api';
 import {stripIndent} from 'common-tags';
-import type {FastifyPluginCallback} from 'fastify';
+import type {FastifyPluginAsync} from 'fastify';
 import plugin from 'fastify-plugin';
 import {range} from 'lodash';
 import moment from 'moment';
@@ -652,7 +652,7 @@ const getNumOptions = () => {
 };
 
 export const server = ({webClient: slack, eventClient, messageClient: slackInteractions}: SlackInterface) => {
-	const callback: FastifyPluginCallback = async (fastify, opts, next) => {
+	const callback: FastifyPluginAsync = async (fastify, opts) => {
 		const among = new Among({slack, eventClient, slackInteractions});
 		await among.initialize();
 
@@ -679,7 +679,6 @@ export const server = ({webClient: slack, eventClient, messageClient: slackInter
 			}
 		});
 
-		next();
 	};
 
 	return plugin(callback);

--- a/google-calendar/index.ts
+++ b/google-calendar/index.ts
@@ -1,6 +1,6 @@
 import type {MessageEvent} from '@slack/web-api';
 import {Mutex} from 'async-mutex';
-import type {FastifyPluginCallback} from 'fastify';
+import type {FastifyPluginAsync} from 'fastify';
 import plugin from 'fastify-plugin';
 import logger from '../lib/logger';
 import type {SlashCommandEndpoint, SlackInterface} from '../lib/slack';
@@ -46,7 +46,7 @@ export default async (slack: SlackInterface) => {
 };
 
 export const server = () => {
-	const callback: FastifyPluginCallback = async (fastify, _opts, next) => {
+	const callback: FastifyPluginAsync = async (fastify, _opts) => {
 		const bot = await botDeferred.promise;
 
 		fastify.post<SlashCommandEndpoint>('/slash/calendar', (req, res) => {
@@ -62,7 +62,6 @@ export const server = () => {
 			return '';
 		});
 
-		next();
 	};
 
 	return plugin(callback);

--- a/nojoin/index.ts
+++ b/nojoin/index.ts
@@ -29,7 +29,7 @@ export const server = async ({eventClient, webClient: slack}: SlackInterface) =>
 		}
 	});
 
-	const callback: FastifyPluginAsync = async (fastify, opts) => {
+	const callback: FastifyPluginAsync = async (fastify, _opts) => {
 		fastify.post<SlashCommandEndpoint>('/slash/nojoin', async (req, res) => {
 			if (req.body.token !== process.env.SLACK_VERIFICATION_TOKEN) {
 				res.code(400);

--- a/nojoin/index.ts
+++ b/nojoin/index.ts
@@ -1,4 +1,4 @@
-import type {FastifyPluginCallback} from 'fastify';
+import type {FastifyPluginAsync} from 'fastify';
 import plugin from 'fastify-plugin';
 import State from '../lib/state';
 import type {SlackInterface, SlashCommandEndpoint} from '../lib/slack';
@@ -29,7 +29,7 @@ export const server = async ({eventClient, webClient: slack}: SlackInterface) =>
 		}
 	});
 
-	const callback: FastifyPluginCallback = async (fastify, opts, next) => {
+	const callback: FastifyPluginAsync = async (fastify, opts) => {
 		fastify.post<SlashCommandEndpoint>('/slash/nojoin', async (req, res) => {
 			if (req.body.token !== process.env.SLACK_VERIFICATION_TOKEN) {
 				res.code(400);

--- a/oogiri/index.ts
+++ b/oogiri/index.ts
@@ -8,7 +8,7 @@ import path from 'path';
 import type {KnownBlock, WebClient} from '@slack/web-api';
 import {Mutex} from 'async-mutex';
 import {stripIndent} from 'common-tags';
-import type {FastifyPluginCallback} from 'fastify';
+import type {FastifyPluginAsync} from 'fastify';
 import plugin from 'fastify-plugin';
 import {flatten, isEmpty, range, shuffle, times, uniq} from 'lodash';
 import type {SlackInterface, SlashCommandEndpoint} from '../lib/slack';
@@ -765,7 +765,7 @@ class Oogiri {
 }
 
 export const server = ({webClient: slack, eventClient, messageClient: slackInteractions}: SlackInterface) => {
-	const callback: FastifyPluginCallback = async (fastify, opts, next) => {
+	const callback: FastifyPluginAsync = async (fastify, opts) => {
 		const oogiri = new Oogiri({slack, eventClient, slackInteractions});
 		await oogiri.initialize();
 
@@ -779,7 +779,6 @@ export const server = ({webClient: slack, eventClient, messageClient: slackInter
 			return oogiri.showStartDialog(req.body.trigger_id, req.body.text);
 		});
 
-		next();
 	};
 
 	return plugin(callback);

--- a/oogiri/index.ts
+++ b/oogiri/index.ts
@@ -765,7 +765,7 @@ class Oogiri {
 }
 
 export const server = ({webClient: slack, eventClient, messageClient: slackInteractions}: SlackInterface) => {
-	const callback: FastifyPluginAsync = async (fastify, opts) => {
+	const callback: FastifyPluginAsync = async (fastify, _opts) => {
 		const oogiri = new Oogiri({slack, eventClient, slackInteractions});
 		await oogiri.initialize();
 

--- a/slow-quiz/index.ts
+++ b/slow-quiz/index.ts
@@ -1435,7 +1435,7 @@ export class SlowQuiz {
 }
 
 export const server = ({webClient: slack, messageClient: slackInteractions}: SlackInterface) => {
-	const callback: FastifyPluginAsync = async (fastify, opts) => {
+	const callback: FastifyPluginAsync = async (fastify, _opts) => {
 		const slowquiz = new SlowQuiz({slack, slackInteractions});
 		await slowquiz.initialize();
 

--- a/slow-quiz/index.ts
+++ b/slow-quiz/index.ts
@@ -6,7 +6,7 @@ import {SlackMessageAdapter} from '@slack/interactive-messages';
 import type {ImageElement, KnownBlock, WebClient} from '@slack/web-api';
 import {Mutex} from 'async-mutex';
 import {oneLine, stripIndent} from 'common-tags';
-import type {FastifyPluginCallback} from 'fastify';
+import type {FastifyPluginAsync} from 'fastify';
 import plugin from 'fastify-plugin';
 // @ts-expect-error: Not typed
 import {hiraganize} from 'japanese';
@@ -1435,7 +1435,7 @@ export class SlowQuiz {
 }
 
 export const server = ({webClient: slack, messageClient: slackInteractions}: SlackInterface) => {
-	const callback: FastifyPluginCallback = async (fastify, opts, next) => {
+	const callback: FastifyPluginAsync = async (fastify, opts) => {
 		const slowquiz = new SlowQuiz({slack, slackInteractions});
 		await slowquiz.initialize();
 
@@ -1469,7 +1469,6 @@ export const server = ({webClient: slack, messageClient: slackInteractions}: Sla
 			});
 		});
 
-		next();
 	};
 
 	return plugin(callback);

--- a/tsglive/index.ts
+++ b/tsglive/index.ts
@@ -5,7 +5,7 @@ import type {SlackInterface, SlashCommandEndpoint} from '../lib/slack';
 import {getMemberName} from '../lib/slackUtils';
 
 export const server = ({webClient: slack}: SlackInterface) => {
-	const callback: FastifyPluginAsync = async (fastify, opts) => {
+	const callback: FastifyPluginAsync = async (fastify, _opts) => {
 		const {team}: any = await slack.team.info();
 
 		fastify.post<SlashCommandEndpoint>('/slash/tsglive', async (req, res) => {

--- a/tsglive/index.ts
+++ b/tsglive/index.ts
@@ -1,11 +1,11 @@
-import type {FastifyPluginCallback} from 'fastify';
+import type {FastifyPluginAsync} from 'fastify';
 import plugin from 'fastify-plugin';
 import {liveDb as db} from '../lib/firestore';
 import type {SlackInterface, SlashCommandEndpoint} from '../lib/slack';
 import {getMemberName} from '../lib/slackUtils';
 
 export const server = ({webClient: slack}: SlackInterface) => {
-	const callback: FastifyPluginCallback = async (fastify, opts, next) => {
+	const callback: FastifyPluginAsync = async (fastify, opts) => {
 		const {team}: any = await slack.team.info();
 
 		fastify.post<SlashCommandEndpoint>('/slash/tsglive', async (req, res) => {
@@ -56,7 +56,6 @@ export const server = ({webClient: slack}: SlackInterface) => {
 			return '';
 		});
 
-		next();
 	};
 
 	return plugin(callback);

--- a/tunnel/index.ts
+++ b/tunnel/index.ts
@@ -33,7 +33,7 @@ const getEmojiImageUrl = async (name: string, team: string): Promise<string> => 
 
 // eslint-disable-next-line import/prefer-default-export
 export const server = ({webClient: tsgSlack, eventClient}: SlackInterface) => {
-	const callback: FastifyPluginAsync = async (fastify, opts) => {
+	const callback: FastifyPluginAsync = async (fastify, _opts) => {
 		const db = await open({
 			filename: path.join(__dirname, '..', 'tokens.sqlite3'),
 			driver: sqlite3.Database,

--- a/tunnel/index.ts
+++ b/tunnel/index.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import {EnvelopedEvent} from '@slack/bolt';
 import {ReactionAddedEvent, ReactionRemovedEvent, WebClient} from '@slack/web-api';
 import {EmojiData} from 'emoji-data-ts';
-import type {FastifyPluginCallback} from 'fastify';
+import type {FastifyPluginAsync} from 'fastify';
 import plugin from 'fastify-plugin';
 import {flatten, uniq} from 'lodash';
 import sql from 'sql-template-strings';
@@ -33,7 +33,7 @@ const getEmojiImageUrl = async (name: string, team: string): Promise<string> => 
 
 // eslint-disable-next-line import/prefer-default-export
 export const server = ({webClient: tsgSlack, eventClient}: SlackInterface) => {
-	const callback: FastifyPluginCallback = async (fastify, opts, next) => {
+	const callback: FastifyPluginAsync = async (fastify, opts) => {
 		const db = await open({
 			filename: path.join(__dirname, '..', 'tokens.sqlite3'),
 			driver: sqlite3.Database,
@@ -245,7 +245,6 @@ export const server = ({webClient: tsgSlack, eventClient}: SlackInterface) => {
 			);
 		}
 
-		next();
 	};
 
 	return plugin(callback);


### PR DESCRIPTION
## 概要

PR #1213 (fastify v5アップグレード) のマージ後、`FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER` が発生し HTTP サーバーの boot が失敗していた問題を修正。

## 原因

fastify v5 では **async プラグインが callback style の第3引数 (`next`) を持つことが禁止** された。

```
FastifyError: The callback-auto-0 plugin being registered mixes async and callback styles.
  code: 'FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER'
```

以下7つのプラグインが `async (fastify, opts, next) => { ... next() }` スタイルを使っており、fastify boot 全体が失敗。その結果 deploy ボットを含む全 HTTP エンドポイントが未登録になっていた。

## 変更内容

`FastifyPluginCallback`（callback style）→ `FastifyPluginAsync`（async style）に変更し、不要な `next()` 呼び出しを削除。

| ファイル | 変更内容 |
|---|---|
| `tunnel/index.ts` | `FastifyPluginAsync`に変更、`next()`を削除 |
| `tsglive/index.ts` | 同上 |
| `nojoin/index.ts` | `FastifyPluginAsync`に変更（`next()`呼び出しなし） |
| `google-calendar/index.ts` | 同上、`next()`を削除 |
| `amongyou/index.ts` | 同上 |
| `oogiri/index.ts` | 同上 |
| `slow-quiz/index.ts` | 同上 |

## テスト

- `npx tsc --noEmit` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)