### PR TITLE
fix: デイリーたほいやのスキップメッセージをスレッドへのbroadcastに変更

### DIFF
--- a/tahoiya/Tahoiya.ts
+++ b/tahoiya/Tahoiya.ts
@@ -596,9 +596,10 @@ export class Tahoiya extends ChannelLimitedBot {
 
 		const humanCount = Object.keys(game.meanings).filter((u) => u.startsWith('U')).length;
 		if (humanCount < DAILY_TAHOIYA_MINIMUM_PARTICIPANTS) {
-			await this.#postMessage({
-				text: `参加者が${DAILY_TAHOIYA_MINIMUM_PARTICIPANTS}人未満のため、デイリーたほいやはスキップされました😢`,
-			});
+			const skipNotice = `参加者が${DAILY_TAHOIYA_MINIMUM_PARTICIPANTS}人未満のため、デイリーたほいやはスキップされました😢`;
+			const themeCount = await this.#countAvailableThemes();
+			const blocks = dailyStatusMessage(game, themeCount, skipNotice);
+			await this.#postThread('daily', {text: skipNotice, blocks, broadcast: true});
 			return;
 		}
 


### PR DESCRIPTION
## Summary

- 参加者不足でデイリーたほいやがスキップされた際のメッセージを、スタンドアロン投稿からゲームスレッドへの `reply_broadcast` 返信に変更
- メッセージ下部に `dailyStatusMessage` を使って現在のお題・参加者数などのゲーム状態を表示するよう追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)