### PR TITLE
Allow read access to tahoiya_games Firestore collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -25,5 +25,8 @@ service cloud.firestore {
     match /twenty_questions_games/{document=**} {
       allow read;
     }
+    match /tahoiya_games/{document=**} {
+      allow read;
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `firestore.rules` に `tahoiya_games` コレクションへの読み取り権限を追加

achievement-viewer (https://github.com/tsg-ut/achievement-viewer/pull/1006) でたほいやゲームログビューアを実装するにあたり、クライアントサイドから `tahoiya_games` コレクションを読み取れるようにする。

## Test plan

- [ ] achievement-viewer の `/records/tahoiya` ページでゲームログが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)