### PR TITLE
fix: PR #1207 以降に顕在化した Discord domain 経由の uncaughtException クラッシュを修正

### DIFF
--- a/discord/hayaoshi.ts
+++ b/discord/hayaoshi.ts
@@ -632,7 +632,7 @@ export default class Hayaoshi extends EventEmitter {
 	}
 
 	onMessage(message: Discord.Message) {
-		if (message.channel.id !== process.env.DISCORD_SANDBOX_TEXT_CHANNEL_ID || message.member.user.bot) {
+		if (message.channel.id !== process.env.DISCORD_SANDBOX_TEXT_CHANNEL_ID || !message.member || message.member.user.bot) {
 			return;
 		}
 

--- a/discord/index.ts
+++ b/discord/index.ts
@@ -82,8 +82,12 @@ export default async ({webClient: slack, eventClient}: SlackInterface) => {
 
 			return;
 		}
-		hayaoshi.onMessage(message);
-		tts.onMessage(message);
+		try {
+			hayaoshi.onMessage(message);
+			tts.onMessage(message);
+		} catch (error) {
+			log.error('Error in messageCreate handler', {error});
+		}
 	});
 
 	discord.on('voiceStateUpdate', (oldState, newState) => {

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,10 @@ process.on('unhandledRejection', (error: Error, promise: Promise<any>) => {
 	log.error(`unhandledRejection at: ${promise} reason: ${error.stack ?? error.message}`, { error, stack: error.stack, promise });
 });
 
+process.on('uncaughtException', (error: Error) => {
+	log.error(`uncaughtException: ${error.stack ?? error.message}`, { error, stack: error.stack });
+});
+
 
 // Disable the cache since it likely hits the swap anyway
 sharp.cache(false);


### PR DESCRIPTION
## 概要

PR #1207（ts-node → plain node への切り替え）によって顕在化した、プロセスクラッシュを修正する。

## 調査ログ

### 事象

2026-06-29T11:46:14 (JST)、特に操作を行っていないにもかかわらずプロセスが自動再起動した。PM2 ログ：

```
PM2 log: App [app:2] exited with code [1] via signal [SIGINT]
PM2 log: App [app:2] starting in -fork mode-
PM2 log: App [app:2] online
```

### 原因調査

**app-error.log に生スタックトレースを発見：**

```
2026-06-29T11:46:14: TypeError: Cannot read properties of null (reading 'user')
    at Hayaoshi.onMessage (/home/slackbot/slackbot/.build/discord/hayaoshi.js:515:98)
    at Client.<anonymous> (/home/slackbot/slackbot/.build/discord/index.js:67:18)
    at Client.emit (node:events:519:28)
    at Client.emit (node:domain:489:12)
    ...
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

**`unhandledRejection` ハンドラーが呼ばれていない：**

`app-out.log` を確認すると、同時刻に JSON 形式の `"unhandledRejection at: ..."` ログが**存在しない**。raw テキストが stderr に出ていること（= Node.js デフォルトの uncaughtException 出力）と合わせて、このエラーは `unhandledRejection` ではなく **`uncaughtException`** として処理されていることを確認。

**Discord.js domain が原因：**

スタックに `at Client.emit (node:domain:489:12)` が含まれる。Discord.js は内部で Node.js の `domain` モジュールを使用しており、`async` イベントハンドラー内で同期的に throw された例外が domain に捕捉されて `uncaughtException` へ昇格する。`index.ts` に `uncaughtException` ハンドラーが存在しないため、Node.js デフォルト動作（stderr 出力 → `process.exit(1)`）が走る。

**同エラーの発生時刻（合計 5 回）：**

| 時刻 (JST) | クラッシュ |
|---|---|
| 2026-06-29T02:35:30 | なし |
| 2026-06-29T04:35:22 | なし |
| 2026-06-29T06:35:12 | なし |
| 2026-06-29T09:39:29 | なし（手動再起動） |
| **2026-06-29T11:46:14** | **クラッシュ** |

**PR #1207 がトリガー：**

02:35〜06:35 のエラーは `app-error.log` に `.ts` ファイルのパスで記録されており、旧ビルド（tsx/ts-node 実行）からのものと判明。ts-node は内部で `source-map-support` を require し、`process.on('uncaughtException', ...)` ハンドラーを登録する。このハンドラーはエラーを stderr に出力するが **`process.exit()` を呼ばない**ため、プロセスが継続していた。

PR #1207（mergedAt: 2026-06-28T23:43:11Z）で plain node に切り替わったことで source-map-support のハンドラーが消え、同じバグが初めてクラッシュとして顕在化した。

### 修正内容

1. **`index.ts`**: `uncaughtException` ハンドラーを追加。ログ出力のみ行い、プロセスは継続する（ts-node 時代の挙動を再現）。
2. **`discord/index.ts`**: `messageCreate` ハンドラー内の `hayaoshi.onMessage` / `tts.onMessage` 呼び出しを `try/catch` で囲む。これにより同期例外が domain 経路を通らず `catch` で処理され、根本的に `uncaughtException` へ昇格しなくなる。
3. **`discord/hayaoshi.ts`**: `onMessage` 内で `message.member` が `null` の場合のガードを追加（直接的な null アクセスの修正）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk77i1XYEfQRRkjHow8JyV