### PR TITLE
fix: ricochet-robots の __dirname 依存パスを process.cwd() に変更

### DIFF
--- a/ricochet-robots/rust-proxy.ts
+++ b/ricochet-robots/rust-proxy.ts
@@ -12,7 +12,7 @@ interface BoardSpec {
 
 export const get_data = async (boardspec: BoardSpec) => {
 	const generator = child_process.spawn(
-											path.join(__dirname,'../target/release/ricochet_robot_problem_generator'), 
+											path.join(process.cwd(),'target/release/ricochet_robot_problem_generator'),
 											[`${boardspec.depth}`,`${boardspec.size.h}`,`${boardspec.size.w}`,`${boardspec.numOfWalls}`]);
 	const output = await new Promise((resolve) => {
 		const stream = concatstream({ encoding: 'buffer' }, (data) => {


### PR DESCRIPTION
## Summary

- `ricochet-robots/rust-proxy.ts` で `__dirname` を使ってRustバイナリのパスを組み立てていた箇所を修正
- PR #1221 と同様の問題：`.build/` からの実行時に `__dirname` が `.build/ricochet-robots/` になり、`../target/release/...` が `.build/target/release/...` に解決されてバイナリが見つからなくなる
- `process.cwd()`（常にプロジェクトルート）を基準にすることで dev/production 両環境で正しいパスに解決される

## Test plan

- [x] 型チェック `npx tsgo --noEmit` が通ることを確認済み

🤖 Generated with [Claude Code](https://claude.ai/claude-code)