### PR TITLE
fix: .build/ 実行時の __dirname 依存パス問題を追加修正 (wordhero, slack/oauth/tunnel)

### DIFF
--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -51,7 +51,7 @@ export const tsgEventClient = new TeamEventClient(eventClient, process.env.TEAM_
 const loadTokensDeferred = new Deferred<Token[]>();
 const loadTokens = async () => {
 	const db = await sqlite.open({
-		filename: path.join(__dirname, '..', 'tokens.sqlite3'),
+		filename: path.join(process.cwd(), 'tokens.sqlite3'),
 		driver: sqlite3.Database,
 	});
 	const tokens: Token[] = await db.all(sql`SELECT * FROM tokens WHERE bot_access_token <> ''`).catch((): Token[] => []);

--- a/oauth/index.ts
+++ b/oauth/index.ts
@@ -11,7 +11,7 @@ const log = logger.child({bot: 'oauth'});
 
 export const server = ({webClient: slack}: SlackInterface) => async (fastify: FastifyInstance) => {
 	const db = await sqlite.open({
-		filename: path.join(__dirname, '..', 'tokens.sqlite3'),
+		filename: path.join(process.cwd(), 'tokens.sqlite3'),
 		driver: sqlite3.Database,
 	});
 	await db.run(`

--- a/tunnel/index.ts
+++ b/tunnel/index.ts
@@ -35,7 +35,7 @@ const getEmojiImageUrl = async (name: string, team: string): Promise<string> => 
 export const server = ({webClient: tsgSlack, eventClient}: SlackInterface) => {
 	const callback: FastifyPluginAsync = async (fastify, _opts) => {
 		const db = await open({
-			filename: path.join(__dirname, '..', 'tokens.sqlite3'),
+			filename: path.join(process.cwd(), 'tokens.sqlite3'),
 			driver: sqlite3.Database,
 		});
 		const kmcToken = await db.get(sql`SELECT * FROM tokens WHERE team_id = ${process.env.KMC_TEAM_ID}`).catch((): null => null);

--- a/wordhero/generateCrossword.ts
+++ b/wordhero/generateCrossword.ts
@@ -23,7 +23,7 @@ const convertToNewFormat = (board: string[]) => (
 
 const generate = async (usedAt: string): Promise<Crossword> => {
 	if (stocks.length === 0) {
-		const generator = spawn('../target/release/crossword_generator_main', {cwd: __dirname});
+		const generator = spawn('target/release/crossword_generator_main', {cwd: process.cwd()});
 		const output = await new Promise<Buffer>((resolve) => {
 			generator.stdout.pipe(concat({encoding: 'buffer'}, (data: Buffer) => {
 				resolve(data);


### PR DESCRIPTION
## Summary

PR #1221 および #1223 (ricochet-robots) で対処した `__dirname` 依存パス問題の追加修正。

`.build/` からの実行時に `__dirname` が変わることで発生するバグを2箇所修正した。

### wordhero/generateCrossword.ts

```diff
- const generator = spawn('../target/release/crossword_generator_main', {cwd: __dirname});
+ const generator = spawn('target/release/crossword_generator_main', {cwd: process.cwd()});
```

ricochet-robots と全く同じパターン。`.build/wordhero/` を `cwd` にして相対パスで起動するため `.build/target/release/crossword_generator_main` に解決されてしまい、バイナリが見つからない。

### lib/slack.ts / oauth/index.ts / tunnel/index.ts

```diff
- filename: path.join(__dirname, '..', 'tokens.sqlite3'),
+ filename: path.join(process.cwd(), 'tokens.sqlite3'),
```

`tokens.sqlite3` はプロジェクトルートに存在するファイル。各ファイルは `.build/lib/` や `.build/oauth/` 配下に置かれるため、`__dirname + '..'` が `.build/tokens.sqlite3` に解決されてしまい、正しいトークンDBを参照できない。

## 調査した結果、問題なしと判断した箇所

- `lib/state.ts` の `__state__` — production では Firestore を使うため無影響
- `summary/summary_writer.js` のフォントパス — `lib/loadFont.ts` も同じく `__dirname` 基準でダウンロードするため、dev/prod ともに一貫したパスになる
- `dajare/tokenize.js` の bep-ss-2.3 参照 — `lib/getReading.js` の `__dirname` ダウンロード先と一致するため問題なし
- プラグイン内の `state.json` — 書き込み先がずれるが `.build/` 内で一貫するため起動クラッシュは発生しない

## Test plan

- [ ] `npx tsgo --noEmit` が通ることを確認済み
- [ ] wordhero のクロスワード生成が正常に動作すること
- [ ] マルチチーム Slack (tunnel bot) のトークン参照が正常に動作すること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)