### PR TITLE
ci: Rust CIのビルドを高速化(依存キャッシュ + sparseレジストリ)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[unstable]
+sparse-registry = true
+
+[source.crates-io]
+replace-with = "sparse+https://index.crates.io/"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,7 @@
 sparse-registry = true
 
 [source.crates-io]
-replace-with = "sparse+https://index.crates.io/"
+replace-with = "sparse-crates-io"
+
+[source.sparse-crates-io]
+registry = "sparse+https://index.crates.io/"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,2 @@
 [unstable]
 sparse-registry = true
-
-[source.crates-io]
-replace-with = "sparse-crates-io"
-
-[source.sparse-crates-io]
-registry = "sparse+https://index.crates.io/"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,10 +67,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: build
-        # Cargo.lockに変更がなければ--offlineでcrates.ioインデックス更新の
-        # ネットワークアクセス(数分かかる)をスキップできる。キャッシュが
-        # 古い/不足している場合のみ通常のオンラインビルドにフォールバックする。
-        run: cargo build --all --verbose --offline || cargo build --all --verbose
+        run: cargo build --all --verbose
 
       - name: test
-        run: cargo test --all --verbose --offline || cargo test --all --verbose
+        run: cargo test --all --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,8 @@ jobs:
           # https://github.com/asdf-vm/actions/issues/587
           asdf_branch: v0.15.0
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: build
         run: cargo build --all --verbose
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: build
-        run: cargo build --all --verbose
+        # Cargo.lockに変更がなければ--offlineでcrates.ioインデックス更新の
+        # ネットワークアクセス(数分かかる)をスキップできる。キャッシュが
+        # 古い/不足している場合のみ通常のオンラインビルドにフォールバックする。
+        run: cargo build --all --verbose --offline || cargo build --all --verbose
 
       - name: test
-        run: cargo test --all --verbose
+        run: cargo test --all --verbose --offline || cargo test --all --verbose


### PR DESCRIPTION
## Summary
- `test-rust` ジョブがキャッシュなしで毎回Rustの依存クレートをフルビルドしており、直近の実行では合計4m49sのうち4m29sが `cargo build --all --verbose` に費やされていた
- `Swatinem/rust-cache@v2` を追加し、`Cargo.lock` ベースで `~/.cargo` と `target/` をキャッシュ
- キャッシュを有効にしても大部分の時間が `Updating crates.io index` (crates.ioのgitベースの巨大なインデックスをネットワーク経由で取得する処理)に費やされていることが判明。`--offline` によるスキップも試したが、Swatinem/rust-cacheがキャッシュサイズ削減のためインデックス実体(`.git`)を保存時に削除する仕様のため、依存解決に必要な情報が失われ常にオンラインビルドへフォールバックしてしまい効果がなかった
- 根本原因である「gitプロトコルでの巨大インデックス取得」自体を解消するため、`.cargo/config.toml` でsparse(HTTP)レジストリプロトコルを有効化。必要なクレートのメタデータのみを取得するようになり、`Updating crates.io index` が数分 → 1秒未満に短縮された

## Result
- `test-rust` ジョブの `build` ステップ: 約4分29秒 → 14秒

## Test plan
- [x] PRのCIで `test-rust` ジョブが正常に完了することを確認
- [x] `Updating crates.io index` が高速化されていることをログで確認
- [x] `cargo test` の結果が従来通り(0 failed)であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)