### PR TITLE
tahoiya: 任意たほいやモードにOpenAIベースのAI参加者を追加

### DIFF
--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -28,7 +28,8 @@ interface OpenAIUsageLog extends DocumentData {
 	cost: number | null; // Cost in USD
 }
 
-const OpenAIUsageLog = db.collection('openai_usage_logs') as CollectionReference<OpenAIUsageLog>;
+// Firestore (and thus usage logging/limiting) is unavailable outside of production; see lib/firestore.ts.
+const OpenAIUsageLog = db ? (db.collection('openai_usage_logs') as CollectionReference<OpenAIUsageLog>) : null;
 
 const openai = new OpenAI({
 	apiKey: process.env.OPENAI_API_KEY,
@@ -45,6 +46,10 @@ const formatDurationInHours = (durationInHours: number): string => {
 };
 
 const checkUsageLimit = async (errorDestination: 'slack' | 'discord'): Promise<void> => {
+	if (!OpenAIUsageLog) {
+		return;
+	}
+
 	const now = new Date();
 	const oneDayAgo = dayjs(now).subtract(1, 'day').toDate();
 	const query = OpenAIUsageLog.where('createdAt', '>=', oneDayAgo).orderBy('createdAt', 'desc');
@@ -133,7 +138,7 @@ const audioSpeechCreate = async (params: SpeechCreateParams): Promise<Response &
 
 	log.info(`OpenAI audio.speech.create API cost: $${cost?.toFixed(4) ?? 'unknown'}`);
 
-	await OpenAIUsageLog.add({
+	await OpenAIUsageLog?.add({
 		method: 'audio.speech.create',
 		createdAt: firestore.FieldValue.serverTimestamp(),
 		model: params.model,
@@ -157,6 +162,7 @@ const checkChatCompletionCreateModel = (params: ChatCompletionCreateParamsNonStr
 		model === 'gpt-4o-mini' ||
 		model === 'gpt-4.1-mini' ||
 		model === 'gpt-5-mini' ||
+		model === 'gpt-5.4-nano' ||
 		model === 'o4-mini'
 	) {
 		return model;
@@ -193,6 +199,11 @@ const chatCompletionCreate = async (params: ChatCompletionCreateParamsNonStreami
 		// Output: $2.00 / 1M tokens
 		// https://platform.openai.com/docs/models/gpt-5-mini
 		cost = (promptTokens / 1_000_000) * 0.25 + (completionTokens / 1_000_000) * 2.00;
+	} else if (model === 'gpt-5.4-nano') {
+		// Input: $0.20 / 1M tokens
+		// Output: $1.25 / 1M tokens
+		// https://developers.openai.com/api/docs/models/gpt-5.4-nano
+		cost = (promptTokens / 1_000_000) * 0.20 + (completionTokens / 1_000_000) * 1.25;
 	} else {
 		assert(model === 'o4-mini', `Unexpected model: ${model}`);
 
@@ -204,7 +215,7 @@ const chatCompletionCreate = async (params: ChatCompletionCreateParamsNonStreami
 
 	log.info(`OpenAI chat.completions.create API cost: $${cost?.toFixed(4) ?? 'unknown'}`);
 
-	await OpenAIUsageLog.add({
+	await OpenAIUsageLog?.add({
 		method: 'chat.completions.create',
 		createdAt: firestore.FieldValue.serverTimestamp(),
 		model: params.model,

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -163,6 +163,7 @@ const checkChatCompletionCreateModel = (params: ChatCompletionCreateParamsNonStr
 		model === 'gpt-4.1-mini' ||
 		model === 'gpt-5-mini' ||
 		model === 'gpt-5.4-nano' ||
+		model === 'gpt-5.4-mini' ||
 		model === 'o4-mini'
 	) {
 		return model;
@@ -204,6 +205,11 @@ const chatCompletionCreate = async (params: ChatCompletionCreateParamsNonStreami
 		// Output: $1.25 / 1M tokens
 		// https://developers.openai.com/api/docs/models/gpt-5.4-nano
 		cost = (promptTokens / 1_000_000) * 0.20 + (completionTokens / 1_000_000) * 1.25;
+	} else if (model === 'gpt-5.4-mini') {
+		// Input: $0.75 / 1M tokens
+		// Output: $4.50 / 1M tokens
+		// https://developers.openai.com/api/docs/models/gpt-5.4-mini
+		cost = (promptTokens / 1_000_000) * 0.75 + (completionTokens / 1_000_000) * 4.50;
 	} else {
 		assert(model === 'o4-mini', `Unexpected model: ${model}`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "node-emoji": "^1.11.0",
         "node-persist": "^3.1.0",
         "node-schedule": "^2.1.0",
-        "openai": "^5.20.2",
+        "openai": "^6.45.0",
         "opentype.js": "^1.3.4",
         "p-queue": "<7.0.0",
         "pino-std-serializers": "^7.1.0",
@@ -31904,18 +31904,27 @@
       }
     },
     "node_modules/openai": {
-      "version": "5.20.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.20.2.tgz",
-      "integrity": "sha512-ZeBIEazj6W/XOulMw92L8iU5FblQeM5IxjPRCZNVArNXsoF+bLPnS7B2X4O0JSmpCM+F5Gdajr6bn4nAUj4LFQ==",
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
         "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },
@@ -38777,9 +38786,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -57897,9 +57906,9 @@
       }
     },
     "openai": {
-      "version": "5.20.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.20.2.tgz",
-      "integrity": "sha512-ZeBIEazj6W/XOulMw92L8iU5FblQeM5IxjPRCZNVArNXsoF+bLPnS7B2X4O0JSmpCM+F5Gdajr6bn4nAUj4LFQ==",
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
       "requires": {}
     },
     "opentype.js": {
@@ -62839,9 +62848,9 @@
       "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w=="
     },
     "zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "node-emoji": "^1.11.0",
     "node-persist": "^3.1.0",
     "node-schedule": "^2.1.0",
-    "openai": "^5.20.2",
+    "openai": "^6.45.0",
     "opentype.js": "^1.3.4",
     "p-queue": "<7.0.0",
     "pino-std-serializers": "^7.1.0",

--- a/tahoiya/Tahoiya.ts
+++ b/tahoiya/Tahoiya.ts
@@ -595,7 +595,6 @@ export class Tahoiya extends ChannelLimitedBot {
 			getArbitraryAIAnswer(
 				arbitraryTheme.question,
 				arbitraryTheme.answer,
-				arbitraryTheme.isMimicryAllowed ?? false,
 			).then((decoyAnswer) => {
 				if (!decoyAnswer) {
 					return;

--- a/tahoiya/Tahoiya.ts
+++ b/tahoiya/Tahoiya.ts
@@ -2,7 +2,6 @@ import {randomUUID} from 'crypto';
 import type {BlockButtonAction, ViewSubmitAction} from '@slack/bolt';
 import type {ChatPostMessageArguments, KnownBlock, GenericMessageEvent} from '@slack/web-api';
 import {Mutex} from 'async-mutex';
-import {stripIndent} from 'common-tags';
 // @ts-expect-error: fast-levenshtein has no type declarations
 import levenshtein from 'fast-levenshtein';
 import {minBy, maxBy, sample, sampleSize, shuffle, sum} from 'lodash';
@@ -54,14 +53,14 @@ const TIME_COLLECT_MEANING_NORMAL = 3 * 60 * 1000;
 const TIME_COLLECT_BETTING_NORMAL = 3 * 60 * 1000;
 const TIME_COLLECT_BETTING_DAILY = 60 * 60 * 1000;
 const DUMMY_SIZE_BASE = 4;
-const DAILY_TAHOIYA_MINIMUM_PARTICIPANTS = 3;
+const DAILY_TAHOIYA_MINIMUM_PARTICIPANTS = process.env.NODE_ENV === 'development' ? 0 : 3;
 
 const AI_BOT_MODELS: AIBotModel[] = ['tahoiyabot-01', 'tahoiyabot-02'];
 const ARBITRARY_AI_BOT_ID = 'tahoiyabot-arbitrary';
 const ALL_AI_BOT_IDS: string[] = [...AI_BOT_MODELS, ARBITRARY_AI_BOT_ID];
 
 export class Tahoiya extends ChannelLimitedBot {
-	protected override wakeWordRegex = /^(?:たほいや|デイリーたほいや|たほいやランキング)$/;
+	protected override wakeWordRegex = /^(?:たほいや|デイリーたほいや|デイリーたほいや開始|たほいやランキング)$/;
 
 	protected override allowedChannels = [process.env.CHANNEL_SANDBOX!];
 
@@ -146,6 +145,10 @@ export class Tahoiya extends ChannelLimitedBot {
 		}
 		if (text === 'デイリーたほいや') {
 			return mutex.runExclusive(() => this.#showDailyStatus(targetChannel, null));
+		}
+		if (process.env.NODE_ENV === 'development' && text === 'デイリーたほいや開始') {
+			mutex.runExclusive(() => this.#triggerDailyBetting());
+			return Promise.resolve(null);
 		}
 		if (text === 'たほいやランキング') {
 			return mutex.runExclusive(() => this.#showRanking(targetChannel));

--- a/tahoiya/Tahoiya.ts
+++ b/tahoiya/Tahoiya.ts
@@ -17,12 +17,14 @@ import type {SlackInterface} from '../lib/slack';
 import State from '../lib/state';
 import {getAIBotMeaning} from './aibot';
 import type {AIBotModel} from './aibot';
+import {getArbitraryAIAnswer} from './arbitraryAibot';
 import {calculateRatingDeltas} from './rating';
 import type {
 	DailyGameState,
 	GameComment,
 	NormalGameState,
 	TahoiyaState,
+	ArbitraryTheme,
 	DictionarySource,
 	DictionaryTheme,
 	ShuffledMeaning,
@@ -55,6 +57,8 @@ const DUMMY_SIZE_BASE = 4;
 const DAILY_TAHOIYA_MINIMUM_PARTICIPANTS = 3;
 
 const AI_BOT_MODELS: AIBotModel[] = ['tahoiyabot-01', 'tahoiyabot-02'];
+const ARBITRARY_AI_BOT_ID = 'tahoiyabot-arbitrary';
+const ALL_AI_BOT_IDS: string[] = [...AI_BOT_MODELS, ARBITRARY_AI_BOT_ID];
 
 export class Tahoiya extends ChannelLimitedBot {
 	protected override wakeWordRegex = /^(?:たほいや|デイリーたほいや|たほいやランキング)$/;
@@ -582,6 +586,31 @@ export class Tahoiya extends ChannelLimitedBot {
 					});
 				}).catch((err) => this.log.error('AI bot error (daily):', err));
 			}
+		}
+
+		// OpenAI-based AI participant submits a decoy answer for arbitrary themes in the background
+		if (theme.theme.type === 'arbitrary') {
+			const arbitraryTheme = theme.theme as ArbitraryTheme;
+
+			getArbitraryAIAnswer(
+				arbitraryTheme.question,
+				arbitraryTheme.answer,
+				arbitraryTheme.isMimicryAllowed ?? false,
+			).then((decoyAnswer) => {
+				if (!decoyAnswer) {
+					return;
+				}
+				mutex.runExclusive(() => {
+					if (this.#state.dailyGame?.themeId !== theme.id) {
+						return;
+					}
+					if (this.#state.dailyGame.phase !== 'collect_meanings') {
+						return;
+					}
+
+					this.#state.dailyGame.meanings[ARBITRARY_AI_BOT_ID] = normalizeMeaning(decoyAnswer);
+				});
+			}).catch((err) => this.log.error('Arbitrary AI bot error (daily):', err));
 		}
 	}
 
@@ -1246,7 +1275,7 @@ export class Tahoiya extends ChannelLimitedBot {
 			return;
 		}
 
-		for (const botId of AI_BOT_MODELS) {
+		for (const botId of ALL_AI_BOT_IDS) {
 			if (!game.meanings[botId]) {
 				continue;
 			}

--- a/tahoiya/arbitraryAibot.test.ts
+++ b/tahoiya/arbitraryAibot.test.ts
@@ -1,0 +1,108 @@
+/* eslint-env jest */
+
+import type {ChatCompletion} from 'openai/resources/chat';
+import openai from '../lib/openai';
+import {getArbitraryAIAnswer} from './arbitraryAibot';
+
+process.env.OPENAI_API_KEY = 'test-api-key';
+
+jest.mock('../lib/openai', () => ({
+	__esModule: true,
+	default: {
+		chat: {
+			completions: {
+				create: jest.fn(),
+			},
+		},
+	},
+}));
+
+const mockContent = (content: string) => ({
+	choices: [{
+		message: {content},
+	}],
+	model: 'gpt-4.1-mini',
+} as ChatCompletion);
+
+describe('tahoiya/arbitraryAibot', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('generates a decoy answer and returns it when judged as incorrect', async () => {
+		jest.mocked(openai.chat.completions.create)
+			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "さよならプラスティックワールド"}'))
+			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
+
+		const result = await getArbitraryAIAnswer('実在するPerfumeのシングルは?', 'ポリリズム', false);
+
+		expect(result).toBe('さよならプラスティックワールド');
+		expect(openai.chat.completions.create).toHaveBeenCalledTimes(2);
+	});
+
+	it('always instructs the model not to answer correctly, regardless of isMimicryAllowed', async () => {
+		jest.mocked(openai.chat.completions.create)
+			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答"}'))
+			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
+
+		await getArbitraryAIAnswer('質問', '正解', true);
+
+		const [[generationCall]] = jest.mocked(openai.chat.completions.create).mock.calls;
+		const prompt = generationCall.messages[0].content as string;
+		expect(prompt).toContain('質問に対して正解となるような回答をしてはいけません');
+	});
+
+	it('regenerates up to 2 times when judged as correct, and returns the answer once judged incorrect', async () => {
+		jest.mocked(openai.chat.completions.create)
+			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答1"}'))
+			.mockResolvedValueOnce(mockContent('{"isCorrect": true}'))
+			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答2"}'))
+			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
+
+		const result = await getArbitraryAIAnswer('質問', '正解', false);
+
+		expect(result).toBe('誤答2');
+		expect(openai.chat.completions.create).toHaveBeenCalledTimes(4);
+	});
+
+	it('gives up and returns null after being judged correct 3 times in a row', async () => {
+		jest.mocked(openai.chat.completions.create)
+			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答1"}'))
+			.mockResolvedValueOnce(mockContent('{"isCorrect": true}'))
+			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答2"}'))
+			.mockResolvedValueOnce(mockContent('{"isCorrect": true}'))
+			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答3"}'))
+			.mockResolvedValueOnce(mockContent('{"isCorrect": true}'));
+
+		const result = await getArbitraryAIAnswer('質問', '正解', false);
+
+		expect(result).toBeNull();
+		expect(openai.chat.completions.create).toHaveBeenCalledTimes(6);
+	});
+
+	it('returns null and does not throw when the generation call fails', async () => {
+		jest.mocked(openai.chat.completions.create).mockRejectedValueOnce(new Error('API error'));
+
+		const result = await getArbitraryAIAnswer('質問', '正解', false);
+
+		expect(result).toBeNull();
+	});
+
+	it('returns null and does not throw when the judge call fails', async () => {
+		jest.mocked(openai.chat.completions.create)
+			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答"}'))
+			.mockRejectedValueOnce(new Error('API error'));
+
+		const result = await getArbitraryAIAnswer('質問', '正解', false);
+
+		expect(result).toBeNull();
+	});
+
+	it('returns null when the response does not contain valid JSON', async () => {
+		jest.mocked(openai.chat.completions.create).mockResolvedValueOnce(mockContent('申し訳ありませんが回答できません'));
+
+		const result = await getArbitraryAIAnswer('質問', '正解', false);
+
+		expect(result).toBeNull();
+	});
+});

--- a/tahoiya/arbitraryAibot.test.ts
+++ b/tahoiya/arbitraryAibot.test.ts
@@ -34,22 +34,34 @@ describe('tahoiya/arbitraryAibot', () => {
 			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "さよならプラスティックワールド"}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
 
-		const result = await getArbitraryAIAnswer('実在するPerfumeのシングルは?', 'ポリリズム', false);
+		const result = await getArbitraryAIAnswer('実在するPerfumeのシングルは?', 'ポリリズム');
 
 		expect(result).toBe('さよならプラスティックワールド');
 		expect(openai.chat.completions.create).toHaveBeenCalledTimes(2);
 	});
 
-	it('always instructs the model not to answer correctly, regardless of isMimicryAllowed', async () => {
+	it('always instructs the model not to answer correctly', async () => {
 		jest.mocked(openai.chat.completions.create)
 			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答"}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
 
-		await getArbitraryAIAnswer('質問', '正解', true);
+		await getArbitraryAIAnswer('質問', '正解');
 
 		const [[generationCall]] = jest.mocked(openai.chat.completions.create).mock.calls;
 		const prompt = generationCall.messages[0].content as string;
 		expect(prompt).toContain('質問に対して正解となるような回答をしてはいけません');
+	});
+
+	it('instructs the judge to also treat alternative correct answers as correct', async () => {
+		jest.mocked(openai.chat.completions.create)
+			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答"}'))
+			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
+
+		await getArbitraryAIAnswer('質問', '正解');
+
+		const [, [judgeCall]] = jest.mocked(openai.chat.completions.create).mock.calls;
+		const prompt = judgeCall.messages[0].content as string;
+		expect(prompt).toContain('別解');
 	});
 
 	it('regenerates up to 2 times when judged as correct, and returns the answer once judged incorrect', async () => {
@@ -59,7 +71,7 @@ describe('tahoiya/arbitraryAibot', () => {
 			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答2"}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
 
-		const result = await getArbitraryAIAnswer('質問', '正解', false);
+		const result = await getArbitraryAIAnswer('質問', '正解');
 
 		expect(result).toBe('誤答2');
 		expect(openai.chat.completions.create).toHaveBeenCalledTimes(4);
@@ -74,7 +86,7 @@ describe('tahoiya/arbitraryAibot', () => {
 			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答3"}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": true}'));
 
-		const result = await getArbitraryAIAnswer('質問', '正解', false);
+		const result = await getArbitraryAIAnswer('質問', '正解');
 
 		expect(result).toBeNull();
 		expect(openai.chat.completions.create).toHaveBeenCalledTimes(6);
@@ -83,7 +95,7 @@ describe('tahoiya/arbitraryAibot', () => {
 	it('returns null and does not throw when the generation call fails', async () => {
 		jest.mocked(openai.chat.completions.create).mockRejectedValueOnce(new Error('API error'));
 
-		const result = await getArbitraryAIAnswer('質問', '正解', false);
+		const result = await getArbitraryAIAnswer('質問', '正解');
 
 		expect(result).toBeNull();
 	});
@@ -93,7 +105,7 @@ describe('tahoiya/arbitraryAibot', () => {
 			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答"}'))
 			.mockRejectedValueOnce(new Error('API error'));
 
-		const result = await getArbitraryAIAnswer('質問', '正解', false);
+		const result = await getArbitraryAIAnswer('質問', '正解');
 
 		expect(result).toBeNull();
 	});
@@ -101,7 +113,7 @@ describe('tahoiya/arbitraryAibot', () => {
 	it('returns null when the response does not contain valid JSON', async () => {
 		jest.mocked(openai.chat.completions.create).mockResolvedValueOnce(mockContent('申し訳ありませんが回答できません'));
 
-		const result = await getArbitraryAIAnswer('質問', '正解', false);
+		const result = await getArbitraryAIAnswer('質問', '正解');
 
 		expect(result).toBeNull();
 	});

--- a/tahoiya/arbitraryAibot.test.ts
+++ b/tahoiya/arbitraryAibot.test.ts
@@ -29,9 +29,9 @@ describe('tahoiya/arbitraryAibot', () => {
 		jest.clearAllMocks();
 	});
 
-	it('generates a decoy answer and returns it when judged as incorrect', async () => {
+	it('generates decoy answer candidates and returns the first one judged as incorrect', async () => {
 		jest.mocked(openai.chat.completions.create)
-			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "さよならプラスティックワールド"}'))
+			.mockResolvedValueOnce(mockContent('{"candidateAnswers": ["さよならプラスティックワールド", "コンピューターシティ"]}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
 
 		const result = await getArbitraryAIAnswer('実在するPerfumeのシングルは?', 'ポリリズム');
@@ -40,21 +40,23 @@ describe('tahoiya/arbitraryAibot', () => {
 		expect(openai.chat.completions.create).toHaveBeenCalledTimes(2);
 	});
 
-	it('always instructs the model not to answer correctly', async () => {
+	it('does not reveal the correct answer in the generation prompt, but instructs the model to avoid answers it believes are correct', async () => {
 		jest.mocked(openai.chat.completions.create)
-			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答"}'))
+			.mockResolvedValueOnce(mockContent('{"candidateAnswers": ["誤答"]}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
 
-		await getArbitraryAIAnswer('質問', '正解');
+		await getArbitraryAIAnswer('質問', 'SECRET_ANSWER_VALUE');
 
 		const [[generationCall]] = jest.mocked(openai.chat.completions.create).mock.calls;
 		const prompt = generationCall.messages[0].content as string;
-		expect(prompt).toContain('質問に対して正解となるような回答をしてはいけません');
+		expect(prompt).not.toContain('SECRET_ANSWER_VALUE');
+		expect(prompt).toContain('質問');
+		expect(prompt).toContain('あなた自身が質問に対して正しいと考える内容を候補に含めてはいけません');
 	});
 
 	it('instructs the judge to also treat alternative correct answers as correct', async () => {
 		jest.mocked(openai.chat.completions.create)
-			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答"}'))
+			.mockResolvedValueOnce(mockContent('{"candidateAnswers": ["誤答"]}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
 
 		await getArbitraryAIAnswer('質問', '正解');
@@ -64,32 +66,28 @@ describe('tahoiya/arbitraryAibot', () => {
 		expect(prompt).toContain('別解');
 	});
 
-	it('regenerates up to 2 times when judged as correct, and returns the answer once judged incorrect', async () => {
+	it('judges candidates in order and skips ones judged as correct within the same attempt', async () => {
 		jest.mocked(openai.chat.completions.create)
-			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答1"}'))
+			.mockResolvedValueOnce(mockContent('{"candidateAnswers": ["候補1", "候補2", "候補3"]}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": true}'))
-			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答2"}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": false}'));
 
 		const result = await getArbitraryAIAnswer('質問', '正解');
 
-		expect(result).toBe('誤答2');
-		expect(openai.chat.completions.create).toHaveBeenCalledTimes(4);
+		expect(result).toBe('候補2');
+		expect(openai.chat.completions.create).toHaveBeenCalledTimes(3);
 	});
 
-	it('gives up and returns null after being judged correct 3 times in a row', async () => {
+	it('gives up and returns null (without regenerating) when every candidate in the single attempt is judged as correct', async () => {
 		jest.mocked(openai.chat.completions.create)
-			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答1"}'))
+			.mockResolvedValueOnce(mockContent('{"candidateAnswers": ["誤答1", "誤答2"]}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": true}'))
-			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答2"}'))
-			.mockResolvedValueOnce(mockContent('{"isCorrect": true}'))
-			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答3"}'))
 			.mockResolvedValueOnce(mockContent('{"isCorrect": true}'));
 
 		const result = await getArbitraryAIAnswer('質問', '正解');
 
 		expect(result).toBeNull();
-		expect(openai.chat.completions.create).toHaveBeenCalledTimes(6);
+		expect(openai.chat.completions.create).toHaveBeenCalledTimes(3);
 	});
 
 	it('returns null and does not throw when the generation call fails', async () => {
@@ -102,7 +100,7 @@ describe('tahoiya/arbitraryAibot', () => {
 
 	it('returns null and does not throw when the judge call fails', async () => {
 		jest.mocked(openai.chat.completions.create)
-			.mockResolvedValueOnce(mockContent('{"decoyAnswer": "誤答"}'))
+			.mockResolvedValueOnce(mockContent('{"candidateAnswers": ["誤答"]}'))
 			.mockRejectedValueOnce(new Error('API error'));
 
 		const result = await getArbitraryAIAnswer('質問', '正解');

--- a/tahoiya/arbitraryAibot.ts
+++ b/tahoiya/arbitraryAibot.ts
@@ -1,0 +1,176 @@
+/* eslint-disable import/prefer-default-export */
+import {stripIndent} from 'common-tags';
+import {z} from 'zod';
+import logger from '../lib/logger';
+import openai from '../lib/openai';
+
+const log = logger.child({bot: 'tahoiya/arbitraryAibot'});
+
+const MODEL = 'gpt-4.1-mini';
+const MAX_ANSWER_LENGTH = 256;
+
+// Initial generation + up to 2 regenerations when the previous attempt is judged correct.
+const MAX_GENERATION_ATTEMPTS = 3;
+
+const DecoyAnswerResponse = z.object({
+	decoyAnswer: z.string().trim().nonempty(),
+});
+
+const JudgeResponse = z.object({
+	isCorrect: z.boolean(),
+});
+
+const extractJson = (content: string): unknown => {
+	const match = content.match(/\{[\s\S]*\}/);
+	if (!match) {
+		throw new Error(`No JSON object found in response: ${content}`);
+	}
+	return JSON.parse(match[0]);
+};
+
+const buildGenerationPrompt = (
+	question: string,
+	answer: string,
+	isMimicryAllowed: boolean,
+	previousAttempts: string[],
+): string => stripIndent`
+	あなたは「たほいや」という言葉遊びゲームの「任意お題モード」に、他のプレイヤーに混じって参加するAIです。
+	このモードでは、出題者があらかじめ「質問」と「正解」の組を用意しており、参加者は正解を知らないまま、他のプレイヤーを騙すための「誤答選択肢」を考えて提出します。
+	最終的に、正解と全参加者の誤答選択肢がシャッフルされて提示され、他のプレイヤーはどれが正解かを当てます。
+
+	# 質問
+	${question}
+
+	# 正解（あなたはこれを知っていますが、誤答選択肢としてこれを使ったり、言い換えて使ったりしてはいけません）
+	${answer}
+
+	# あなたのタスク
+	以下の手順で思考しながら、この質問に対する「誤答選択肢」を1つ作成してください。
+
+	1. 質問の分野・意図と、正解の形式（固有名詞か説明文か、文体、大まかな分量など）を分析する。
+	2. 分析結果を踏まえ、正解と似た形式でありながら内容が異なる、もっともらしい誤答の候補を3つ挙げる。
+	3. 各候補について、他のプレイヤーが正解と誤認しそうな説得力があるかを吟味し、最も優れた候補を1つ選ぶ。
+	4. 選んだ候補の内容が、正解と実質的に同じ意味になっていないかを再確認し、もし同じ意味であれば候補を修正する。
+
+	# 重要な注意事項（必ず守ること）
+	- どのような場合であっても、質問に対して正解となるような回答をしてはいけません。これはこのゲームの設定（正解を答えることが許可されているかどうか）に関わらず、常に守ってください。
+	- 誤答選択肢は日本語で、正解と同程度の分量・自然さにしてください。
+	- 誤答選択肢は${MAX_ANSWER_LENGTH}文字以内にしてください。
+	${isMimicryAllowed ? '- このゲームでは人間の参加者が正解をそのまま登録することも許可されていますが、あなたは必ず誤答を作成してください。' : ''}
+	${previousAttempts.length > 0 ? stripIndent`
+
+		# 補足
+		以下の誤答選択肢は、実質的に正解と同じ内容であると判定され、却下されました。これらとは異なる、正解ではないことがより明確な誤答選択肢を考えてください。
+		${previousAttempts.map((attempt, i) => `${i + 1}. ${attempt}`).join('\n')}
+	` : ''}
+
+	最後に、これまでの思考過程を踏まえて、以下のJSON形式のみを出力してください。それ以外の文章は一切出力しないでください。
+	\`\`\`
+	{"decoyAnswer": "誤答選択肢の文字列"}
+	\`\`\`
+`;
+
+const buildJudgePrompt = (question: string, answer: string, candidateAnswer: string): string => stripIndent`
+	あなたは「たほいや」という言葉遊びゲームにおける、回答の正解判定を行う審判です。
+	以下の「質問」と「正解」に対して、「判定対象の回答」が正解として扱われるべきかどうかを判定してください。
+
+	# 質問
+	${question}
+
+	# 正解
+	${answer}
+
+	# 判定対象の回答
+	${candidateAnswer}
+
+	表記ゆれ・言い回しの違い・言語の違いなどは無視し、意味内容が正解と実質的に同じであれば true 、
+	正解とは異なる内容であれば false としてください。
+
+	以下のJSON形式のみを出力してください。それ以外の文章は一切出力しないでください。
+	\`\`\`
+	{"isCorrect": true または false}
+	\`\`\`
+`;
+
+const generateDecoyAnswer = async (
+	question: string,
+	answer: string,
+	isMimicryAllowed: boolean,
+	previousAttempts: string[],
+): Promise<string | null> => {
+	const response = await openai.chat.completions.create({
+		model: MODEL,
+		messages: [
+			{role: 'user', content: buildGenerationPrompt(question, answer, isMimicryAllowed, previousAttempts)},
+		],
+		max_tokens: 1024,
+	});
+
+	const content = response?.choices?.[0]?.message?.content;
+	if (!content) {
+		log.warn('No content found in the decoy generation response');
+		return null;
+	}
+
+	const parsed = DecoyAnswerResponse.parse(extractJson(content));
+	return parsed.decoyAnswer.slice(0, MAX_ANSWER_LENGTH);
+};
+
+const judgeIsCorrect = async (question: string, answer: string, candidateAnswer: string): Promise<boolean> => {
+	const response = await openai.chat.completions.create({
+		model: MODEL,
+		messages: [
+			{role: 'user', content: buildJudgePrompt(question, answer, candidateAnswer)},
+		],
+		max_tokens: 256,
+	});
+
+	const content = response?.choices?.[0]?.message?.content;
+	if (!content) {
+		throw new Error('No content found in the judge response');
+	}
+
+	const parsed = JudgeResponse.parse(extractJson(content));
+	return parsed.isCorrect;
+};
+
+// Returns null if generation fails, the API is unavailable, or every attempt ends up
+// being judged as a correct answer, so the caller can just skip AI participation.
+export const getArbitraryAIAnswer = async (
+	question: string,
+	answer: string,
+	isMimicryAllowed: boolean,
+): Promise<string | null> => {
+	const previousAttempts: string[] = [];
+
+	for (let attempt = 1; attempt <= MAX_GENERATION_ATTEMPTS; attempt++) {
+		let decoyAnswer: string | null = null;
+
+		try {
+			decoyAnswer = await generateDecoyAnswer(question, answer, isMimicryAllowed, previousAttempts);
+		} catch (error) {
+			log.error(`Failed to generate decoy answer (attempt ${attempt}): ${(error as Error)?.message ?? error}`);
+			return null;
+		}
+
+		if (!decoyAnswer) {
+			return null;
+		}
+
+		try {
+			const isCorrect = await judgeIsCorrect(question, answer, decoyAnswer);
+			if (!isCorrect) {
+				return decoyAnswer;
+			}
+			log.warn(`Decoy answer "${decoyAnswer}" was judged as correct (attempt ${attempt}/${MAX_GENERATION_ATTEMPTS})`);
+		} catch (error) {
+			log.error(`Failed to judge decoy answer (attempt ${attempt}): ${(error as Error)?.message ?? error}`);
+			return null;
+		}
+
+		previousAttempts.push(decoyAnswer);
+	}
+
+	log.warn(`Gave up generating a decoy answer for question "${question}" after ${MAX_GENERATION_ATTEMPTS} attempts`);
+	return null;
+};

--- a/tahoiya/arbitraryAibot.ts
+++ b/tahoiya/arbitraryAibot.ts
@@ -31,7 +31,6 @@ const extractJson = (content: string): unknown => {
 const buildGenerationPrompt = (
 	question: string,
 	answer: string,
-	isMimicryAllowed: boolean,
 	previousAttempts: string[],
 ): string => stripIndent`
 	あなたは「たほいや」という言葉遊びゲームの「任意お題モード」に、他のプレイヤーに混じって参加するAIです。
@@ -53,10 +52,9 @@ const buildGenerationPrompt = (
 	4. 選んだ候補の内容が、正解と実質的に同じ意味になっていないかを再確認し、もし同じ意味であれば候補を修正する。
 
 	# 重要な注意事項（必ず守ること）
-	- どのような場合であっても、質問に対して正解となるような回答をしてはいけません。これはこのゲームの設定（正解を答えることが許可されているかどうか）に関わらず、常に守ってください。
+	- どのような場合であっても、質問に対して正解となるような回答をしてはいけません。
 	- 誤答選択肢は日本語で、正解と同程度の分量・自然さにしてください。
 	- 誤答選択肢は${MAX_ANSWER_LENGTH}文字以内にしてください。
-	${isMimicryAllowed ? '- このゲームでは人間の参加者が正解をそのまま登録することも許可されていますが、あなたは必ず誤答を作成してください。' : ''}
 	${previousAttempts.length > 0 ? stripIndent`
 
 		# 補足
@@ -72,19 +70,25 @@ const buildGenerationPrompt = (
 
 const buildJudgePrompt = (question: string, answer: string, candidateAnswer: string): string => stripIndent`
 	あなたは「たほいや」という言葉遊びゲームにおける、回答の正解判定を行う審判です。
-	以下の「質問」と「正解」に対して、「判定対象の回答」が正解として扱われるべきかどうかを判定してください。
+	以下の「質問」と「参考正解」に対して、「判定対象の回答」が正解として扱われるべきかどうかを判定してください。
 
 	# 質問
 	${question}
 
-	# 正解
+	# 参考正解
 	${answer}
 
 	# 判定対象の回答
 	${candidateAnswer}
 
-	表記ゆれ・言い回しの違い・言語の違いなどは無視し、意味内容が正解と実質的に同じであれば true 、
-	正解とは異なる内容であれば false としてください。
+	この任意お題モードでは、質問に対する正解は「参考正解」の一つに限定されるとは限りません。「参考正解」はあくまで
+	正解の一例であり、判定対象の回答が「参考正解」と文字列としては異なっていても、あなたの知識に基づいて質問に
+	対する事実として正しい別解であると判断できる場合は、正解として扱ってください。
+	一方で、判定対象の回答が「参考正解」とも別解とも言えず、質問に対して誤った内容である場合は、誤答として
+	扱ってください。
+
+	表記ゆれ・言い回しの違い・言語の違いなどは無視し、意味内容が正解（別解を含む）と実質的に同じであれば true 、
+	正解・別解のいずれでもない誤った内容であれば false としてください。
 
 	以下のJSON形式のみを出力してください。それ以外の文章は一切出力しないでください。
 	\`\`\`
@@ -95,13 +99,12 @@ const buildJudgePrompt = (question: string, answer: string, candidateAnswer: str
 const generateDecoyAnswer = async (
 	question: string,
 	answer: string,
-	isMimicryAllowed: boolean,
 	previousAttempts: string[],
 ): Promise<string | null> => {
 	const response = await openai.chat.completions.create({
 		model: MODEL,
 		messages: [
-			{role: 'user', content: buildGenerationPrompt(question, answer, isMimicryAllowed, previousAttempts)},
+			{role: 'user', content: buildGenerationPrompt(question, answer, previousAttempts)},
 		],
 		max_tokens: 1024,
 	});
@@ -139,7 +142,6 @@ const judgeIsCorrect = async (question: string, answer: string, candidateAnswer:
 export const getArbitraryAIAnswer = async (
 	question: string,
 	answer: string,
-	isMimicryAllowed: boolean,
 ): Promise<string | null> => {
 	const previousAttempts: string[] = [];
 
@@ -147,7 +149,7 @@ export const getArbitraryAIAnswer = async (
 		let decoyAnswer: string | null = null;
 
 		try {
-			decoyAnswer = await generateDecoyAnswer(question, answer, isMimicryAllowed, previousAttempts);
+			decoyAnswer = await generateDecoyAnswer(question, answer, previousAttempts);
 		} catch (error) {
 			log.error(`Failed to generate decoy answer (attempt ${attempt}): ${(error as Error)?.message ?? error}`);
 			return null;

--- a/tahoiya/arbitraryAibot.ts
+++ b/tahoiya/arbitraryAibot.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export */
+import {inspect} from 'util';
 import {stripIndent} from 'common-tags';
 import {z} from 'zod';
 import logger from '../lib/logger';
@@ -6,7 +7,7 @@ import openai from '../lib/openai';
 
 const log = logger.child({bot: 'tahoiya/arbitraryAibot'});
 
-const MODEL = 'gpt-4.1-mini';
+const MODEL = 'gpt-5.4-nano';
 const MAX_ANSWER_LENGTH = 256;
 
 // Initial generation + up to 2 regenerations when the previous attempt is judged correct.
@@ -40,19 +41,20 @@ const buildGenerationPrompt = (
 	# 質問
 	${question}
 
-	# 正解（あなたはこれを知っていますが、誤答選択肢としてこれを使ったり、言い換えて使ったりしてはいけません）
+	# 正解（あなたはこれを知っていますが、誤答選択肢としてこれを使ったり、言い換えて使ったり、近い分野の回答を作成してはいけません）
 	${answer}
 
 	# あなたのタスク
 	以下の手順で思考しながら、この質問に対する「誤答選択肢」を1つ作成してください。
 
 	1. 質問の分野・意図と、正解の形式（固有名詞か説明文か、文体、大まかな分量など）を分析する。
-	2. 分析結果を踏まえ、正解と似た形式でありながら内容が異なる、もっともらしい誤答の候補を3つ挙げる。
+	2. 分析結果を踏まえ、正解と似た形式でありながら内容が全く異なる、もっともらしい誤答の候補を、自由な発想で3つ挙げる。
 	3. 各候補について、他のプレイヤーが正解と誤認しそうな説得力があるかを吟味し、最も優れた候補を1つ選ぶ。
-	4. 選んだ候補の内容が、正解と実質的に同じ意味になっていないかを再確認し、もし同じ意味であれば候補を修正する。
+	4. 選んだ候補の内容が、正解と実質的に同じ意味になっていないか、正解と近すぎないかを再確認し、もし同じ意味であれば候補を修正する。
 
 	# 重要な注意事項（必ず守ること）
 	- どのような場合であっても、質問に対して正解となるような回答をしてはいけません。
+	- 上に挙げた正解と似た分野の回答を作ることは避け、自由な発想で、正解と全く異なる内容の誤答選択肢を作ってください。
 	- 誤答選択肢は日本語で、正解と同程度の分量・自然さにしてください。
 	- 誤答選択肢は${MAX_ANSWER_LENGTH}文字以内にしてください。
 	${previousAttempts.length > 0 ? stripIndent`
@@ -65,6 +67,11 @@ const buildGenerationPrompt = (
 	最後に、これまでの思考過程を踏まえて、以下のJSON形式のみを出力してください。それ以外の文章は一切出力しないでください。
 	\`\`\`
 	{"decoyAnswer": "誤答選択肢の文字列"}
+	\`\`\`
+
+	出力例:
+	\`\`\`
+	{"decoyAnswer": "${answer}"}
 	\`\`\`
 `;
 
@@ -82,10 +89,8 @@ const buildJudgePrompt = (question: string, answer: string, candidateAnswer: str
 	${candidateAnswer}
 
 	この任意お題モードでは、質問に対する正解は「参考正解」の一つに限定されるとは限りません。「参考正解」はあくまで
-	正解の一例であり、判定対象の回答が「参考正解」と文字列としては異なっていても、あなたの知識に基づいて質問に
-	対する事実として正しい別解であると判断できる場合は、正解として扱ってください。
-	一方で、判定対象の回答が「参考正解」とも別解とも言えず、質問に対して誤った内容である場合は、誤答として
-	扱ってください。
+	正解の一例であり、判定対象の回答が「参考正解」と文字列としては異なっていても、あなたの知識に基づいて質問に対する事実として正しい別解であると判断できる場合は、正解として扱ってください。
+	一方で、判定対象の回答が「参考正解」とも別解とも言えず、質問に対して誤った内容である場合は、誤答として扱ってください。
 
 	表記ゆれ・言い回しの違い・言語の違いなどは無視し、意味内容が正解（別解を含む）と実質的に同じであれば true 、
 	正解・別解のいずれでもない誤った内容であれば false としてください。
@@ -106,8 +111,11 @@ const generateDecoyAnswer = async (
 		messages: [
 			{role: 'user', content: buildGenerationPrompt(question, answer, previousAttempts)},
 		],
-		max_tokens: 1024,
+		max_completion_tokens: 2048,
+		reasoning_effort: 'medium',
 	});
+
+	log.debug(inspect(response, {depth: null}));
 
 	const content = response?.choices?.[0]?.message?.content;
 	if (!content) {
@@ -125,7 +133,8 @@ const judgeIsCorrect = async (question: string, answer: string, candidateAnswer:
 		messages: [
 			{role: 'user', content: buildJudgePrompt(question, answer, candidateAnswer)},
 		],
-		max_tokens: 256,
+		max_completion_tokens: 128,
+		reasoning_effort: 'none',
 	});
 
 	const content = response?.choices?.[0]?.message?.content;

--- a/tahoiya/arbitraryAibot.ts
+++ b/tahoiya/arbitraryAibot.ts
@@ -7,14 +7,20 @@ import openai from '../lib/openai';
 
 const log = logger.child({bot: 'tahoiya/arbitraryAibot'});
 
-const MODEL = 'gpt-5.4-nano';
+const MODEL = 'gpt-5.4-mini';
 const MAX_ANSWER_LENGTH = 256;
+const CANDIDATE_COUNT = 5;
 
-// Initial generation + up to 2 regenerations when the previous attempt is judged correct.
-const MAX_GENERATION_ATTEMPTS = 3;
+const MAX_GENERATION_ATTEMPTS = 1;
+
+// Worst-case cost per daily tahoiya (question/answer at Slack's 3000-char input cap, all
+// candidates but the last judged as correct so all judge calls run): 1 generation call
+// (~3.7k input / up to 4096 output tokens) + up to 5 judge calls (~6.9k input / 128 output
+// tokens each) ≈ 38k input + 4.7k output tokens. At gpt-5.4-mini pricing ($0.75 / $4.50 per
+// 1M tokens) that's about $0.05 per daily tahoiya.
 
 const DecoyAnswerResponse = z.object({
-	decoyAnswer: z.string().trim().nonempty(),
+	candidateAnswers: z.array(z.string().trim().nonempty()).min(1),
 });
 
 const JudgeResponse = z.object({
@@ -31,47 +37,41 @@ const extractJson = (content: string): unknown => {
 
 const buildGenerationPrompt = (
 	question: string,
-	answer: string,
 	previousAttempts: string[],
 ): string => stripIndent`
 	あなたは「たほいや」という言葉遊びゲームの「任意お題モード」に、他のプレイヤーに混じって参加するAIです。
 	このモードでは、出題者があらかじめ「質問」と「正解」の組を用意しており、参加者は正解を知らないまま、他のプレイヤーを騙すための「誤答選択肢」を考えて提出します。
 	最終的に、正解と全参加者の誤答選択肢がシャッフルされて提示され、他のプレイヤーはどれが正解かを当てます。
 
+	以下の質問に対して、もっともらしい回答の候補を${CANDIDATE_COUNT}個考えてください。
+	後ほど、あなたの知らない実際の正解と照らし合わせて判定が行われ、正解ではないと判定された候補の中から1つが、あなたの誤答選択肢として採用されます。
+
 	# 質問
 	${question}
 
-	# 正解（あなたはこれを知っていますが、誤答選択肢としてこれを使ったり、言い換えて使ったり、近い分野の回答を作成してはいけません）
-	${answer}
-
 	# あなたのタスク
-	以下の手順で思考しながら、この質問に対する「誤答選択肢」を1つ作成してください。
+	以下の手順で思考しながら、この質問に対する回答の候補を${CANDIDATE_COUNT}個作成してください。
 
-	1. 質問の分野・意図と、正解の形式（固有名詞か説明文か、文体、大まかな分量など）を分析する。
-	2. 分析結果を踏まえ、正解と似た形式でありながら内容が全く異なる、もっともらしい誤答の候補を、自由な発想で3つ挙げる。
-	3. 各候補について、他のプレイヤーが正解と誤認しそうな説得力があるかを吟味し、最も優れた候補を1つ選ぶ。
-	4. 選んだ候補の内容が、正解と実質的に同じ意味になっていないか、正解と近すぎないかを再確認し、もし同じ意味であれば候補を修正する。
+	1. 質問の分野・意図を分析し、想定される回答の形式（固有名詞か説明文か、文体、大まかな分量など）を推測する。
+	2. 分析結果を踏まえ、もっともらしい回答の候補を、互いに異なる方向性（別の固有名詞、別の解釈など）で自由な発想で${CANDIDATE_COUNT}個挙げる。
+	3. 各候補について、あなた自身の知識に照らして質問に対する正しい回答になっていないかを確認し、正しい回答になっていると思われる候補があれば別の候補に差し替える。
+	4. 各候補が、質問に対する回答として他のプレイヤーに正解と誤認されうるだけの自然さ・説得力があるかを吟味する。
 
 	# 重要な注意事項（必ず守ること）
-	- どのような場合であっても、質問に対して正解となるような回答をしてはいけません。
-	- 上に挙げた正解と似た分野の回答を作ることは避け、自由な発想で、正解と全く異なる内容の誤答選択肢を作ってください。
-	- 誤答選択肢は日本語で、正解と同程度の分量・自然さにしてください。
-	- 誤答選択肢は${MAX_ANSWER_LENGTH}文字以内にしてください。
+	- どのような場合であっても、あなた自身が質問に対して正しいと考える内容を候補に含めてはいけません。あなたの知識から見て事実として正しいと考えられる回答は、実際の正解と一致する（＝却下される）可能性が高いため、必ず避けてください。
+	- ${CANDIDATE_COUNT}個の候補は、それぞれ内容が重複しないようにしてください。
+	- 候補は日本語で、質問に対して自然な分量・文体にしてください。
+	- 各候補は${MAX_ANSWER_LENGTH}文字以内にしてください。
 	${previousAttempts.length > 0 ? stripIndent`
 
 		# 補足
-		以下の誤答選択肢は、実質的に正解と同じ内容であると判定され、却下されました。これらとは異なる、正解ではないことがより明確な誤答選択肢を考えてください。
+		以下の候補は、いずれも実際の正解と一致すると判定され、却下されました。これらとは異なる候補を考えてください。
 		${previousAttempts.map((attempt, i) => `${i + 1}. ${attempt}`).join('\n')}
 	` : ''}
 
 	最後に、これまでの思考過程を踏まえて、以下のJSON形式のみを出力してください。それ以外の文章は一切出力しないでください。
 	\`\`\`
-	{"decoyAnswer": "誤答選択肢の文字列"}
-	\`\`\`
-
-	出力例:
-	\`\`\`
-	{"decoyAnswer": "${answer}"}
+	{"candidateAnswers": ["候補1", "候補2", "候補3", "候補4", "候補5"]}
 	\`\`\`
 `;
 
@@ -101,17 +101,16 @@ const buildJudgePrompt = (question: string, answer: string, candidateAnswer: str
 	\`\`\`
 `;
 
-const generateDecoyAnswer = async (
+const generateDecoyAnswerCandidates = async (
 	question: string,
-	answer: string,
 	previousAttempts: string[],
-): Promise<string | null> => {
+): Promise<string[] | null> => {
 	const response = await openai.chat.completions.create({
 		model: MODEL,
 		messages: [
-			{role: 'user', content: buildGenerationPrompt(question, answer, previousAttempts)},
+			{role: 'user', content: buildGenerationPrompt(question, previousAttempts)},
 		],
-		max_completion_tokens: 2048,
+		max_completion_tokens: 4096,
 		reasoning_effort: 'medium',
 	});
 
@@ -124,7 +123,9 @@ const generateDecoyAnswer = async (
 	}
 
 	const parsed = DecoyAnswerResponse.parse(extractJson(content));
-	return parsed.decoyAnswer.slice(0, MAX_ANSWER_LENGTH);
+	return parsed.candidateAnswers
+		.slice(0, CANDIDATE_COUNT)
+		.map((candidate) => candidate.slice(0, MAX_ANSWER_LENGTH));
 };
 
 const judgeIsCorrect = async (question: string, answer: string, candidateAnswer: string): Promise<boolean> => {
@@ -146,8 +147,8 @@ const judgeIsCorrect = async (question: string, answer: string, candidateAnswer:
 	return parsed.isCorrect;
 };
 
-// Returns null if generation fails, the API is unavailable, or every attempt ends up
-// being judged as a correct answer, so the caller can just skip AI participation.
+// Returns null if generation fails, the API is unavailable, or every candidate across every attempt
+// ends up being judged as a correct answer, so the caller can just skip AI participation.
 export const getArbitraryAIAnswer = async (
 	question: string,
 	answer: string,
@@ -155,31 +156,33 @@ export const getArbitraryAIAnswer = async (
 	const previousAttempts: string[] = [];
 
 	for (let attempt = 1; attempt <= MAX_GENERATION_ATTEMPTS; attempt++) {
-		let decoyAnswer: string | null = null;
+		let candidates: string[] | null = null;
 
 		try {
-			decoyAnswer = await generateDecoyAnswer(question, answer, previousAttempts);
+			candidates = await generateDecoyAnswerCandidates(question, previousAttempts);
 		} catch (error) {
-			log.error(`Failed to generate decoy answer (attempt ${attempt}): ${(error as Error)?.message ?? error}`);
+			log.error(`Failed to generate decoy answer candidates (attempt ${attempt}): ${(error as Error)?.message ?? error}`);
 			return null;
 		}
 
-		if (!decoyAnswer) {
+		if (!candidates || candidates.length === 0) {
 			return null;
 		}
 
-		try {
-			const isCorrect = await judgeIsCorrect(question, answer, decoyAnswer);
-			if (!isCorrect) {
-				return decoyAnswer;
+		for (const candidate of candidates) {
+			try {
+				const isCorrect = await judgeIsCorrect(question, answer, candidate);
+				if (!isCorrect) {
+					return candidate;
+				}
+				log.warn(`Candidate answer "${candidate}" was judged as correct (attempt ${attempt}/${MAX_GENERATION_ATTEMPTS})`);
+			} catch (error) {
+				log.error(`Failed to judge candidate answer (attempt ${attempt}): ${(error as Error)?.message ?? error}`);
+				return null;
 			}
-			log.warn(`Decoy answer "${decoyAnswer}" was judged as correct (attempt ${attempt}/${MAX_GENERATION_ATTEMPTS})`);
-		} catch (error) {
-			log.error(`Failed to judge decoy answer (attempt ${attempt}): ${(error as Error)?.message ?? error}`);
-			return null;
 		}
 
-		previousAttempts.push(decoyAnswer);
+		previousAttempts.push(...candidates);
 	}
 
 	log.warn(`Gave up generating a decoy answer for question "${question}" after ${MAX_GENERATION_ATTEMPTS} attempts`);


### PR DESCRIPTION
## Summary
- デイリーたほいやの「任意お題モード」に、既存の辞書たほいや（`tahoiyabot-01`/`tahoiyabot-02`）と同様の仕組みでAI参加者（`tahoiyabot-arbitrary`）を追加
- 誤答選択肢の生成には OpenAI (`gpt-4.1-mini`) を使用し、数ステップの手順を踏むCoT形式のプロンプトで生成
- 生成後、別のAPI呼び出しで「質問」「AIが考えた誤答選択肢」の組を渡して正解判定を行い、正解と判定された場合は理由を添えて最大2回まで再生成する
- プロンプトには `isMimicryAllowed` の設定によらず、常に「質問に対して正解となるような回答をしてはいけない」旨を明記
- `lib/openai.ts` 経由のAPI呼び出しが失敗した場合でも、AI参加者なしでゲームが継続できるようエラーハンドリング

## 変更内容
- `tahoiya/arbitraryAibot.ts`: 新規追加。誤答選択肢生成・正解判定ロジック
- `tahoiya/arbitraryAibot.test.ts`: 新規追加。生成成功/再生成/上限到達/API失敗/不正レスポンス時の挙動をテスト
- `tahoiya/Tahoiya.ts`: `#updateDailyGameTheme` の任意お題テーマ分岐でAI参加者を起動し、`#doAIBets` が新しいAI参加者IDも含めて投票するように対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vn8UKMnHrk2KyCGhAbL4Ed