### PR TITLE
fix: 事前ビルド後のアセットコピーで.yml/.md/.png/.mp3等が欠落する問題を修正

### DIFF
--- a/bin/copy-build-assets.mts
+++ b/bin/copy-build-assets.mts
@@ -21,12 +21,27 @@ const EXCLUDE_PATTERNS = [
     '.gemini',
     '.claude',
     '.vscode',
+    '.github',
     'bench_',
     'rust_test_',
     'settings.json',
     'launch.json',
     '.test.',
+    '.gitignore',
+    '.gitattributes',
+    '.gitkeep',
+    '.firebaserc',
+    'README.md',
+    'AGENTS.md',
+    'CLAUDE.md',
+    'codecov.yml',
 ];
+
+// tsgo (allowJs 有効) が .build/ に出力する拡張子。手動コピーは不要。
+const COMPILED_EXTENSIONS = /\.(ts|tsx|js|jsx|mts|cts)$/;
+
+// リポジトリ管理用で実行時に読み込まれない拡張子。
+const NON_ASSET_EXTENSIONS = /\.(rs|toml|py|sh|lock|example|patch|rules|ai)$/;
 
 const exists = async (f: string): Promise<boolean> => {
     try {
@@ -44,10 +59,12 @@ const copy = async (src: string, dest: string) => {
 };
 
 // Absolute path (e.g. /usr/bin/git) is intentionally avoided to support cross-platform builds (Linux, macOS).
+// 拡張子のホワイトリスト方式は新しいアセット種別（.yml, .md, .png, .mp3 等）が追加される度に
+// 欠落を繰り返してきたため、コンパイル対象/非アセットの拡張子のみを除外するブラックリスト方式にしている。
 const trackedFiles = spawnSync('git', ['ls-files'], {encoding: 'utf-8'}) // NOSONAR
     .stdout
     .split('\n')
-    .filter((f) => f.match(/\.(json|geojson|txt|csv|html)$/))
+    .filter((f) => f && !COMPILED_EXTENSIONS.test(f) && !NON_ASSET_EXTENSIONS.test(f))
     .filter((f) => !EXCLUDE_PATTERNS.some((ex) => f.includes(ex)));
 
 for (const f of trackedFiles) {


### PR DESCRIPTION
## Summary

PR #1207 (ts-node → tsgo による事前ビルド化) 以降、`bin/copy-build-assets.mts` のコピー対象拡張子が `json/geojson/txt/csv/html` のみのホワイトリストだったため、以下のbotが `.build/` に必要なアセットが存在せず実行時に `ENOENT` で機能不全に陥っていました。

- `oneiromancy`: `prompt.yml` / `newyear-prompt.yml` が欠落 → 夢占い機能(🔮リアクション)が常に失敗
- `sunrise`: `prompts/*.md` が欠落 → AI生成の天気コメント機能(「天気」「雨」「気温」キーワード応答)が失敗
- `shogi`: `images/*.png` (駒画像) が欠落 → 盤面レンダリングが失敗
- `wordhero`: クロスワード盤面 `.png` が欠落
- `mail-hook` / `slow-quiz` / `autogen-quiz`: プロンプト `.yml`/`.yaml` が欠落
- `discord`: 早押しの効果音 `.mp3` が欠落
- `emoji-modifier`: `thinking-hand.png` が欠落 (相対パス参照のため実害なし)

なお、ユーザー報告の "lyrics/sunrise の毎朝の投稿停止" のうち、本番エラーログで実際に確認できた403/404エラーはスクレイピング先サイト側の一時的な問題で本PRとは無関係です。ただし `sunrise` の `本日の天気` 定期投稿とは別に、キーワード応答型のAI天気コメント機能は上記の欠落により恒常的に壊れていました。

## 原因と修正方針

拡張子のホワイトリスト方式は、新しいアセット種別 (`.yml`, `.md`, `.png`, `.mp3` 等) が追加される度に欠落を繰り返す構造的な弱点があります (実際、`.json`/`.geojson` 拡張子の欠落も過去に一度別の障害を起こし、その場しのぎの対応がされていました)。

今回、tsgo (allowJs) がコンパイル・出力する拡張子 (`.ts/.tsx/.js/.jsx/.mts/.cts`) と、実行時に読み込まれない非アセット拡張子 (`.rs/.toml/.py/.sh/.lock/.example/.patch/.rules/.ai`) のみを除外するブラックリスト方式に変更しました。これにより今後新しいアセット種別が追加されても自動的にコピーされるようになります。

併せて `README.md` / `AGENTS.md` / `CLAUDE.md` / `.github/` 配下など、コピーしても実行時に不要なドキュメント・設定ファイルは `EXCLUDE_PATTERNS` に追加して除外しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj3iDZekHUKG6AoUNVBdhS