### PR TITLE
fix: CIの3種類のCheck失敗のうち2件を修正(Dockerビルド・functionsビルド)

### DIFF
--- a/.devcontainer/slackbot/Dockerfile
+++ b/.devcontainer/slackbot/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -y && \
     # https://github.com/Automattic/node-canvas/wiki/Installation%3A-Ubuntu-and-other-Debian-based-systems
     apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev -y && \
     # Install other dependencies
-    apt-get install git curl bash gnupg -y && \
+    apt-get install git curl bash gnupg unzip -y && \
     # Setup asdf
     git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.15.0 && \
     echo ". $HOME/.asdf/asdf.sh" >> ~/.bashrc && \

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -5,6 +5,7 @@
     "noUnusedLocals": true,
     "esModuleInterop": true,
     "outDir": "lib",
+    "rootDir": "src",
     "sourceMap": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Summary

masterブランチの最新コミットで5種類中3種類のCheckが失敗していた問題のうち、原因が特定できた2件を修正します(SonarCloudのQuality Gate失敗は別途対応が必要なため本PRの対象外)。

- **build-and-push-image**: `.devcontainer/slackbot/Dockerfile` の `npm install` 時、Puppeteer(v25.2.0)がChrome for Testingのzipアーカイブを展開しようとして `unzip` コマンドが見つからず失敗していました。`apt-get install` の対象パッケージに `unzip` を追加しました。
- **Deploy Firebase Configuration**: `functions/tsconfig.json` に `rootDir` が未設定のため、`tsc` → `tsgo` 移行後のビルドで `TS5011` エラーが発生していました。`rootDir: "src"` を明示的に指定しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj3iDZekHUKG6AoUNVBdhS