### PR TITLE
デプロイ処理のnpm ciがNODE_ENV=production継承によりtsgoを含むdevDependenciesをスキップする問題を修正

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -37,7 +37,10 @@ const getChangedFiles = (): string[] => {
 const buildConditionalCommands = (changedFiles: string[]): string[][] => {
 	const commands: string[][] = [];
 	if (changedFiles.includes('package-lock.json')) {
-		commands.push(['npm', 'ci']);
+		// NODE_ENV=production (loaded from .env by this app) is inherited by
+		// spawned npm processes, which makes npm ci skip devDependencies
+		// such as tsgo. Force-include them since the build step needs them.
+		commands.push(['npm', 'ci', '--include=dev']);
 	}
 	if (changedFiles.some((f) => f.endsWith('.rs'))) {
 		commands.push(['/home/slackbot/.cargo/bin/cargo', 'build', '--release', '--all']);


### PR DESCRIPTION
## Summary

#1232 (microsoft-cognitiveservices-speech-sdkのpreinstallスクリプト競合の修正)をマージ後も、本番デプロイ時に `sh: 1: tsgo: not found` が再発しました。真の原因は別にあり、切り分けのため本番サーバーに再度ログインして調査しました。

### 原因

- 本番の `.env` に `NODE_ENV=production` が設定されている
- `index.ts` の `dotenv.config({override: true})` によって、この値がアプリの `process.env` にロードされる
- `deploy` プラグインは同じプロセス内で動作しており、`child_process.spawn(command, args, {cwd: process.cwd()})` で `npm ci` / `npm run build` を起動する際に `env` を明示していないため、`NODE_ENV=production` がそのまま子プロセスに継承される
- **npm 10.9.3 では `NODE_ENV=production` が設定されていると `npm ci` は devDependencies を丸ごとスキップする**(ローカルで再現・確認済み: 空の `dependencies`/`devDependencies` を持つテストプロジェクトで `NODE_ENV=production npm ci` を実行するとdevDependenciesが一切インストールされないことを確認)
- `tsgo` (`@typescript/native-preview`) は `devDependencies` に含まれるため、毎回のデプロイでインストールされずビルドが失敗していた
- ユーザーが手動でSSHして `npm ci` を実行すると直るのは、対話シェルには `NODE_ENV=production` が(通常は)設定されていないため

#1232 で修正した speed-sdk の `preinstall` スクリプト競合も実在する別のバグでしたが、今回の再発の本質的な原因ではありませんでした。

### 修正内容

`deploy/index.ts` の `buildConditionalCommands` 内で `npm ci` に `--include=dev` を明示的に付与し、`NODE_ENV` の値によらず常に devDependencies をインストールするようにしました。`--include=dev` が `NODE_ENV=production` によるスキップを上書きすることもローカルで確認済みです。

## Test plan

- [x] `NODE_ENV=production npm ci` がdevDependenciesをスキップすることをローカルで確認
- [x] `NODE_ENV=production npm ci --include=dev` がdevDependenciesを正しくインストールすることをローカルで確認
- [x] `npx tsgo --project tsconfig.build.json` が型エラーなく通ることを確認
- [x] `npx vitest run deploy` が既存テストを壊していないことを確認
- [ ] 実際の本番デプロイで `npm run build` が連続して成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQJ26zjqsW6x9YgRkrAXFG